### PR TITLE
Fix error pkg_resources.DistributionNotFound: odoo==9.0c

### DIFF
--- a/9.0/bin/docker-entrypoint.sh
+++ b/9.0/bin/docker-entrypoint.sh
@@ -12,7 +12,8 @@ USER_ID=${LOCAL_USER_ID:-9001}
 echo "Starting with UID : $USER_ID"
 id -u odoo &> /dev/null || useradd --shell /bin/bash -u $USER_ID -o -c "" -m odoo
 
-BASEDIR=$(dirname $0)
+BINDIR=$(dirname $0)
+BASEDIR=$(readlink -f $BINDIR/..)
 
 # Accepted values for DEMO: True / False
 # Odoo use a reverse boolean for the demo, which is not handy,
@@ -56,7 +57,7 @@ case "$(echo "${DEMO}" | tr '[:upper:]' '[:lower:]' )" in
 esac
 
 # Create configuration file from the template
-CONFIGDIR=$BASEDIR/../etc
+CONFIGDIR=$BASEDIR/etc
 if [ -e $CONFIGDIR/openerp.cfg.tmpl ]; then
   dockerize -template $CONFIGDIR/openerp.cfg.tmpl:$CONFIGDIR/openerp.cfg
 fi
@@ -66,8 +67,20 @@ if [ ! -f "$CONFIGDIR/openerp.cfg" ]; then
   exit 1
 fi
 
+if [ -z "$(pip list | grep "/opt/odoo/src")" ]; then
+  # The build runs 'pip install -e' on the odoo src, which creates an
+  # odoo.egg-info directory *inside /opt/odoo/src*. So when we run a container
+  # with a volume shared with the host, we don't have this .egg-info (at least
+  # the first time).
+  # When it happens, we reinstall the odoo python package. We don't want to run
+  # the install everytime because it would slow the start of the containers
+  echo '/opt/odoo/src/odoo.egg-info is missing, probably because the directory is a volume.'
+  echo 'Running pip install -e /opt/odoo/src to restore odoo.egg-info'
+  pip install -e $BASEDIR/src
+fi
+
 # Wait until postgres is up
-$BASEDIR/wait_postgres.sh
+$BINDIR/wait_postgres.sh
 
 BASE_CMD=$(basename $1)
 if [ "$BASE_CMD" = "odoo.py" ]; then

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,10 @@ Release History
 Unreleased
 ++++++++++
 
+**Fixes**
+
+* Fix error ``pkg_resources.DistributionNotFound: odoo==9.0c`` happening at the
+  start of the container when we use a host volume for the odoo's src.
 
 1.0.2 (2016-07-12)
 ++++++++++++++++++


### PR DESCRIPTION
The build runs `pip install -e` on the odoo src, which creates an
odoo.egg-info directory *inside /opt/odoo/src*. So when we run a
container with a volume shared with the host, we don't have this
.egg-info (at least the first time).

Correction: When it happens, we reinstall the odoo package. We don't want to run it anytime
because it would slow the start of the containers