### PR TITLE
Add pytest

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -85,18 +85,21 @@ ENV ODOO_VERSION=10.0 \
     ADDONS_PATH=/opt/odoo/local-src,/opt/odoo/src/addons \
     OPENERP_SERVER=/opt/odoo/etc/odoo.cfg
 
-ENTRYPOINT ["./bin/docker-entrypoint.sh"]
+# set to /opt so we can have the same path outside and inside of the container:
+# docker run --rm odoo pytest odoo/external-src/abc/xyz/tests/test.py
+WORKDIR "/opt"
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]
 
 # intermediate images should help speed up builds when only local-src, or only
 # external-src changes
-ONBUILD COPY ./src src
-ONBUILD COPY ./external-src external-src
-ONBUILD COPY ./local-src local-src
-ONBUILD COPY ./data data
-ONBUILD COPY ./songs songs
-ONBUILD COPY ./setup.py ./
-ONBUILD COPY ./VERSION ./
-ONBUILD COPY ./migration.yml ./
+ONBUILD COPY ./src /opt/odoo/src
+ONBUILD COPY ./external-src /opt/odoo/external-src
+ONBUILD COPY ./local-src /opt/odoo/local-src
+ONBUILD COPY ./data /opt/odoo/data
+ONBUILD COPY ./songs /opt/odoo/songs
+ONBUILD COPY ./setup.py /opt/odoo/
+ONBUILD COPY ./VERSION /opt/odoo/
+ONBUILD COPY ./migration.yml /opt/odoo/
 # need to be called at the end, because it installs . and src
-ONBUILD RUN pip install -r src_requirements.txt
+ONBUILD RUN cd /opt/odoo && pip install -r src_requirements.txt

--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -58,3 +58,6 @@ anthem==0.5.0
 
 # test / lint
 flake8
+pytest
+pytest-odoo
+watchdog

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -86,18 +86,21 @@ ENV ODOO_VERSION=9.0 \
     ADDONS_PATH=/opt/odoo/local-src,/opt/odoo/src/addons \
     OPENERP_SERVER=/opt/odoo/etc/odoo.cfg
 
-ENTRYPOINT ["./bin/docker-entrypoint.sh"]
+# set to /opt so we can have the same path outside and inside of the container:
+# docker run --rm odoo pytest odoo/external-src/abc/xyz/tests/test.py
+WORKDIR "/opt"
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]
 
 # intermediate images should help speed up builds when only local-src, or only
 # external-src changes
-ONBUILD COPY ./src src
-ONBUILD COPY ./external-src external-src
-ONBUILD COPY ./local-src local-src
-ONBUILD COPY ./data data
-ONBUILD COPY ./songs songs
-ONBUILD COPY ./setup.py ./
-ONBUILD COPY ./VERSION ./
-ONBUILD COPY ./migration.yml ./
+ONBUILD COPY ./src /opt/odoo/src
+ONBUILD COPY ./external-src /opt/odoo/external-src
+ONBUILD COPY ./local-src /opt/odoo/local-src
+ONBUILD COPY ./data /opt/odoo/data
+ONBUILD COPY ./songs /opt/odoo/songs
+ONBUILD COPY ./setup.py /opt/odoo/
+ONBUILD COPY ./VERSION /opt/odoo/
+ONBUILD COPY ./migration.yml /opt/odoo/
 # need to be called at the end, because it installs . and src
-ONBUILD RUN pip install -r src_requirements.txt
+ONBUILD RUN cd /opt/odoo && pip install -r src_requirements.txt

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -53,3 +53,6 @@ anthem==0.5.0
 
 # test / lint
 flake8
+pytest
+pytest-odoo
+watchdog

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -56,6 +56,7 @@ becomes:
 **Features and Improvements**
 
 * Include pytest
+* Add testdb-gen, command that generates a test database to be used with pytest
 
 **Bugfixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -57,6 +57,7 @@ becomes:
 
 * Include pytest
 * Add testdb-gen, command that generates a test database to be used with pytest
+* Add testdb-update, command to update the addons of a database created with testdb-gen
 
 **Bugfixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -58,6 +58,8 @@ becomes:
 * Include pytest
 * Add testdb-gen, command that generates a test database to be used with pytest
 * Add testdb-update, command to update the addons of a database created with testdb-gen
+* run 'chown' on the volumes only if the user is different, should make the boot faster
+* run 'chown' for any command, not only when starting odoo, needed to run testdb-gen
 
 **Bugfixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,7 +21,41 @@ Release History
 Unreleased
 ++++++++++
 
+**Warning**
+
+Compatibility break:
+the Workdir of the container will be ``/opt`` instead of ``/opt/odoo``.
+The reason is that it allows a more natural transition between the project from
+the outside of the container and from the inside. Meaning, if we run the following command:
+
+::
+
+  docker-compose run --rm -e DB_NAME=dbtest odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes
+
+The path ``odoo/local-src...`` is the path you see in your project (with auto-completion),
+but it is valid from inside the container too.
+
+The implication is that the projects' Dockerfile need to be adapted, for instance:
+
+::
+
+  COPY ./requirements.txt ./
+  RUN pip install -r requirements.txt
+  COPY ./importer.sh bin/
+
+becomes:
+
+::
+
+  COPY ./requirements.txt /opt/odoo/
+  RUN cd /opt/odoo && pip install -r requirements.txt
+
+  COPY ./importer.sh /opt/odoo/bin/
+
+
 **Features and Improvements**
+
+* Include pytest
 
 **Bugfixes**
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,33 @@ By the way, you can add other `ENV` variables in your project's `Dockerfile` if 
 
 Inside the container, a script `runtests` is used for running the tests on Travis.
 It will create a new database, find the local addons, install them and run their tests.
+
+```
+docker-compose run --rm odoo runtests
+```
+
+
 This is not the day-to-day tool for running the tests as a developer.
 
 pytest is included and can be invoked when starting a container. It needs an existing database to run the tests:
 
 ```
-docker-compose run --rm -e DB_NAME=dbtest odoo testdb-gen -i my_addon
-docker-compose run --rm -e DB_NAME=dbtest odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes
+docker-compose run --rm -e DB_NAME=testdb odoo testdb-gen -i my_addon
+docker-compose run --rm -e DB_NAME=testdb odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes
 ```
 
-It uses a plugin (https://github.com/camptocamp/pytest-odoo) that corrects the
+When you make changes in the addon, you need to update it in Odoo before running the tests again. You can use:
+
+```
+docker-compose run --rm -e DB_NAME=testdb odoo testdb-update -u my_addon
+```
+
+When you are done, you can drop the database with:
+
+```
+docker-compose run --rm odoo dropdb testdb
+```
+
+
+Pytest uses a plugin (https://github.com/camptocamp/pytest-odoo) that corrects the
 Odoo namespaces (`openerp.addons`/`odoo.addons`) when running the tests.

--- a/README.md
+++ b/README.md
@@ -102,3 +102,19 @@ ENV ADDONS_PATH=/opt/odoo/local-src,/opt/odoo/external-src/server-tools,/opt/odo
 By setting this value in the `Dockerfile`, it will be integrated into the build and thus will be consistent across each environment.
 
 By the way, you can add other `ENV` variables in your project's `Dockerfile` if you want to customize the default values of some variables for a project.
+
+## Running tests
+
+Inside the container, a script `runtests` is used for running the tests on Travis.
+It will create a new database, find the local addons, install them and run their tests.
+This is not the day-to-day tool for running the tests as a developer.
+
+pytest is included and can be invoked when starting a container. It needs an existing database to run the tests:
+
+```
+docker-compose run --rm -e DB_NAME=dbtest -e MIGRATE=False -e DEMO=True odoo odoo --workers=0 --log-level=warn --stop-after-init -i my_addon
+docker-compose run --rm -e DB_NAME=dbtest odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes
+```
+
+It uses a plugin (https://github.com/camptocamp/pytest-odoo) that corrects the
+Odoo namespaces (`openerp.addons`/`odoo.addons`) when running the tests.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This is not the day-to-day tool for running the tests as a developer.
 pytest is included and can be invoked when starting a container. It needs an existing database to run the tests:
 
 ```
-docker-compose run --rm -e DB_NAME=dbtest -e MIGRATE=False -e DEMO=True odoo odoo --workers=0 --log-level=warn --stop-after-init -i my_addon
+docker-compose run --rm -e DB_NAME=dbtest odoo testdb-gen -i my_addon
 docker-compose run --rm -e DB_NAME=dbtest odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes
 ```
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -92,12 +92,16 @@ fi
 # Wait until postgres is up
 $BINDIR/wait_postgres.sh
 
+mkdir -p /data/odoo/{addons,filestore,sessions}
+if [ ! "$(stat -c '%U' /data/odoo)" = "odoo" ]; then
+  chown -R odoo: /data/odoo
+fi
+if [ ! "$(stat -c '%U' /var/log/odoo)" = "odoo" ]; then
+  chown -R odoo: /var/log/odoo
+fi
+
 BASE_CMD=$(basename $1)
 if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] ; then
-
-  mkdir -p /data/odoo/{addons,filestore,sessions}
-  chown -R odoo: /data/odoo
-  chown -R odoo: /var/log/odoo
 
   if [ -z "$MIGRATE" -o "$MIGRATE" = True ]; then
       gosu odoo migrate

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -100,7 +100,7 @@ if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] ; then
   chown -R odoo: /var/log/odoo
 
   if [ -z "$MIGRATE" -o "$MIGRATE" = True ]; then
-      gosu odoo bin/migrate
+      gosu odoo migrate
   fi
   exec gosu odoo "$@"
 fi

--- a/bin/testdb-gen
+++ b/bin/testdb-gen
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Generate a test database
+#
+# Usage:
+#
+# testdb-gen -i my_addon_to_install
+#
+
+set -e
+
+if psql -lqtA -h db | grep -q "^$DB_NAME|"; then
+  echo "database ${DB_NAME} already exists"
+  exit 1
+fi
+
+echo "creating database ${DB_NAME}"
+createdb -h db -O $DB_USER ${DB_NAME}
+gosu odoo odoo --stop-after-init --workers=0 --log-level=warn --without-demo="" "$@"
+echo "done"

--- a/bin/testdb-update
+++ b/bin/testdb-update
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Run updates of addons on an existing test database
+#
+# Usage:
+#
+# testdb-update -u my_addon
+#
+
+set -e
+
+if ! psql -lqtA -h db | grep -q "^$DB_NAME|"; then
+  echo "database ${DB_NAME} does not exist"
+  exit 1
+fi
+
+echo "updating database ${DB_NAME}"
+gosu odoo odoo --stop-after-init --workers=0 --log-level=warn --without-demo="" "$@"
+echo "done"

--- a/example/docker-compose.override.yml
+++ b/example/docker-compose.override.yml
@@ -12,6 +12,7 @@ services:
       - 8069
       - 8072
     volumes:
+      - "data-odoo-pytest-cache:/opt/odoo/.cache"
       - "./odoo/src:/opt/odoo/src"
       - "./odoo/local-src:/opt/odoo/local-src"
       - "./odoo/external-src:/opt/odoo/external-src"
@@ -29,3 +30,8 @@ services:
   nginx:
     ports:
       - 80:80
+
+volumes:
+  # store pytest cache, allowing to use --lf or --ff (replay last or first failures)
+  data-odoo-pytest-cache:
+

--- a/example/odoo/Dockerfile
+++ b/example/odoo/Dockerfile
@@ -9,7 +9,7 @@ RUN set -x; \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
-COPY ./requirements.txt .
-RUN pip install -r requirements.txt
+COPY ./requirements.txt /opt/odoo/
+RUN cd /opt/odoo && pip install -r requirements.txt
 
 ENV ADDONS_PATH=/opt/odoo/local-src,/opt/odoo/src/addons


### PR DESCRIPTION
pytest is included and can be invoked when starting a container. It needs an existing database to run the tests:

```
docker-compose run --rm -e DB_NAME=dbtest -e MIGRATE=False -e DEMO=True odoo odoo --workers=0 --log-level=warn --stop-after-init -i my_addon
docker-compose run --rm -e DB_NAME=dbtest odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes
```

**Warning**

Compatibility break:
the Workdir of the container will be ``/opt`` instead of ``/opt/odoo``.
The reason is that it allows a more natural transition between the project from
the outside of the container and from the inside. Meaning, if we run the following command:


    docker-compose run --rm -e DB_NAME=dbtest odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes

The path ``odoo/local-src...`` is the path you see in your project (with auto-completion),
but it is valid from inside the container too.

The implication is that the projects' Dockerfile need to be adapted, for instance:


    COPY ./requirements.txt ./
    RUN pip install -r requirements.txt
    COPY ./importer.sh bin/

becomes:


    COPY ./requirements.txt /opt/odoo/
    RUN cd /opt/odoo && pip install -r requirements.txt
    COPY ./importer.sh /opt/odoo/bin/

Uses: https://github.com/camptocamp/pytest-odoo