### PR TITLE
Add DB_HOST environment variable

### DIFF
--- a/10.0/etc/odoo.cfg.tmpl
+++ b/10.0/etc/odoo.cfg.tmpl
@@ -2,7 +2,7 @@
 addons_path = {{ .Env.ADDONS_PATH }}
 data_dir = /data/odoo
 auto_reload = False
-db_host = db
+db_host = {{ default .Env.DB_HOST "db" }}
 db_name = {{ .Env.DB_NAME }}
 db_user = {{ .Env.DB_USER }}
 db_password = {{ .Env.DB_PASSWORD }}


### PR DESCRIPTION
Hello,

It might be convenient to be able to set the DB_HOST variable instead of specifying the extra_host when launching.
It's little config and retro-compatible with the default value.