### PR TITLE
Add custom scripts in /opt/odoo/start-entrypoint.d

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -66,6 +66,7 @@ RUN curl https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize
 COPY ./src_requirements.txt ./
 COPY ./bin bin
 COPY ./etc etc
+COPY ./start-entrypoint.d start-entrypoint.d
 COPY ./MANIFEST.in ./
 
 VOLUME ["/data/odoo", "/var/log/odoo"]

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -67,6 +67,7 @@ COPY ./src_requirements.txt ./
 COPY ./bin bin
 COPY ./bin_compat bin_compat
 COPY ./etc etc
+COPY ./start-entrypoint.d start-entrypoint.d
 COPY ./MANIFEST.in ./
 
 VOLUME ["/data/odoo", "/var/log/odoo"]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,7 +32,7 @@ the outside of the container and from the inside. Meaning, if we run the followi
 
   docker-compose run --rm -e DB_NAME=dbtest odoo pytest -s odoo/local-src/my_addon/tests/test_feature.py::TestFeature::test_it_passes
 
-The path ``odoo/local-src...`` is the path you see in your project (with auto-completion),
+The path ``odoo/local-src...`` is the path you see in your local project (with auto-completion),
 but it is valid from inside the container too.
 
 The implication is that the projects' Dockerfile need to be adapted, for instance:
@@ -58,8 +58,13 @@ becomes:
 * Include pytest
 * Add testdb-gen, command that generates a test database to be used with pytest
 * Add testdb-update, command to update the addons of a database created with testdb-gen
-* run 'chown' on the volumes only if the user is different, should make the boot faster
-* run 'chown' for any command, not only when starting odoo, needed to run testdb-gen
+* 'chown' is executed on the volumes only if the user is different, should make the boot faster
+* 'chown' is executed for any command, not only when starting odoo, needed to run testdb-gen
+* Customizable ``web.base.url`` with environment variables ``ODOO_BASE_URL`` or
+  ``DOMAIN_NAME``
+* Allow to run custom scripts between ``migrate`` and the execution of
+  ``odoo``, by placing them in ``/opt/odoo/start-entrypoint.d`` (respecting
+  ``run-parts`` naming rules)
 
 **Bugfixes**
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 	$(eval TMP := $(shell mktemp -u))
 	cp -r $(VERSION) $(TMP)
 	cp -r bin/ $(TMP)
+	cp -r start-entrypoint.d/ $(TMP)
 	docker build --no-cache -t $(IMAGE_LATEST) $(TMP)
 	rm -rf $(TMP)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Ports 8069 and 8072 are exposed by default.
 
 ## Environment variables
 
+### ODOO_BASE_URL
+
+If this variable is set, the `ir.config_parameter` `web.base.url`
+will be automatically set to this domain when the container
+starts. `web.base.url.freeze` will be set to `True`.
+
 ### MIGRATE
 
 `MIGRATE` can be `True` or `False` and determines whether migration tool
@@ -137,3 +143,16 @@ docker-compose run --rm odoo dropdb testdb
 
 Pytest uses a plugin (https://github.com/camptocamp/pytest-odoo) that corrects the
 Odoo namespaces (`openerp.addons`/`odoo.addons`) when running the tests.
+
+## Start entrypoint
+
+Any script in any language placed in `/opt/odoo/start-entrypoint.d` will be
+executed just between the migration and the start of Odoo. The order of
+execution of the files is determined by the `run-parts` 's rules.
+
+The database is guaranteed to exist at this point so you can run queries on it.
+The scripts are run only if the command is `odoo`/`odoo.py`.
+
+You can add your own scripts in this directory. They must be named something
+like `010_abc` (`^[a-zA-Z0-9_-]+$`) and must have no extension (or it would not
+be picked up by `run-parts`).

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -106,6 +106,12 @@ if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] ; then
   if [ -z "$MIGRATE" -o "$MIGRATE" = True ]; then
       gosu odoo migrate
   fi
+
+  START_ENTRYPOINT_DIR=/opt/odoo/start-entrypoint.d
+  if [ -d "$START_ENTRYPOINT_DIR" ]; then
+    /bin/run-parts --verbose "$START_ENTRYPOINT_DIR"
+  fi
+
   exec gosu odoo "$@"
 fi
 

--- a/start-entrypoint.d/000_set_base_url
+++ b/start-entrypoint.d/000_set_base_url
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+DOMAIN=${ODOO_BASE_URL:-${DOMAIN_NAME}}
+
+if [ -n "$DOMAIN" ]; then
+  echo "Setting Base URL to domain ${DOMAIN}"
+  psql --quiet -h db << EOF
+
+  WITH update_param AS (
+    UPDATE ir_config_parameter
+    SET value = '${DOMAIN}'
+    WHERE key = 'web.base.url'
+    RETURNING *
+  )
+  INSERT INTO ir_config_parameter
+  (value, key, create_uid, write_uid, create_date, write_date)
+  SELECT '${DOMAIN}', 'web.base.url', 1, 1, now(), now()
+  WHERE NOT EXISTS (SELECT * FROM update_param);
+
+  WITH update_param AS (
+    UPDATE ir_config_parameter
+    SET value = 'True'
+    WHERE key = 'web.base.url.freeze'
+    RETURNING *
+  )
+  INSERT INTO ir_config_parameter
+  (value, key, create_uid, write_uid, create_date, write_date)
+  SELECT 'True', 'web.base.url.freeze', 1, 1, now(), now()
+  WHERE NOT EXISTS (SELECT * FROM update_param);
+
+EOF
+fi


### PR DESCRIPTION
Any script in any language placed in `/opt/odoo/start-entrypoint.d` will be
executed just between the migration and the start of Odoo. The order of
execution of the files is determined by the `run-parts` 's rules.

The database is guaranteed to exist at this point so you can run queries on it.
The scripts are run only if the command is `odoo`/`odoo.py`.

You can add your own scripts in this directory. They must be named something
like `010_abc` (`^[a-zA-Z0-9_-]+$`) and must have no extension (or it would not
be picked up by `run-parts`).