### PR TITLE
[fix] Remove deprecated download.gna.org for PyChart

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -1,12 +1,10 @@
-# pychart is not in pypi, and gna.org is http only
-http://download.gna.org/pychart/PyChart-1.39.tar.gz
-
 # Odoo dependencies
 Babel==1.3
 Jinja2==2.7.3
 Mako==1.0.1
 MarkupSafe==0.23
 Pillow==2.7.0
+Python-Chart==1.39
 PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -1,12 +1,10 @@
-# pychart is not in pypi, and gna.org is http only
-http://download.gna.org/pychart/PyChart-1.39.tar.gz
-
 # Odoo dependencies
 Babel==1.3
 Jinja2==2.7.3
 Mako==1.0.0
 MarkupSafe==0.23
 Pillow==2.6.1
+Python-Chart==1.39
 PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1


### PR DESCRIPTION
See https://github.com/OCA/maintainer-quality-tools/commit/5b4b67e757611ac393aaf4434195ca5aa0cd4502