### PR TITLE
Add ofxparse as requirement as seen in odoo

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -23,6 +23,7 @@ html5lib==0.999
 lxml==3.4.1
 mock==1.0.1
 odfpy==1.3.4
+ofxparse==0.16
 passlib==1.6.2
 psutil==2.1.1
 psycopg2==2.5.4

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -22,6 +22,7 @@ html5lib==0.999
 lxml==3.4.0
 mock==1.0.1
 odfpy==1.3.4
+ofxparse==0.14
 passlib==1.6.1
 psutil==2.1.1
 psycopg2==2.5.4

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,6 +31,8 @@ Unreleased
 
 **Libraries**
 
+* Add ``ofxparse`` as found in odoo's requirements
+
 **Build**
 
 **Documentation**


### PR DESCRIPTION
It is a requirement from odoo. For now we are unable to build an image.