### PR TITLE
Add odoo-autodiscover  to base_requirements 

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -21,6 +21,7 @@ html5lib==0.999
 lxml==3.4.1
 mock==1.0.1
 odfpy==1.3.4
+odoo-autodiscover>=2.0.0b1
 ofxparse==0.16
 passlib==1.6.2
 psutil==2.1.1


### PR DESCRIPTION
Add odoo-autodiscover to base_requirements to enable working with Odoo addons packaged as python wheels. (Version 10.0)

Solves https://github.com/camptocamp/docker-odoo-project/issues/38