### PR TITLE
Add future on images with python 2.7 to be able to have cross python …

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -13,6 +13,7 @@ colorama==0.3.2
 decorator==3.4.0
 docutils==0.12
 feedparser==5.1.3
+future==0.16.0
 gevent==1.0.2
 gdata==2.0.18
 greenlet==0.4.7

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -13,6 +13,7 @@ colorama==0.3.2
 decorator==3.4.0
 docutils==0.12
 feedparser==5.1.3
+future==0.16.0
 gevent==1.0.2
 greenlet==0.4.2
 html2text==2016.9.19


### PR DESCRIPTION
…tools

This prepare the arrival of odoo v11