### PR TITLE
Use pip development version

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -41,6 +41,7 @@ RUN set -x; \
             zlib1g-dev \
             libfreetype6-dev \
             tcl expect \
+            git \
         && curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
         && apt-get update \
         && apt-get install -y --no-install-recommends \
@@ -52,7 +53,7 @@ RUN set -x; \
         && apt-get -y install -f --no-install-recommends \
         && pip install -U pip && pip install -r base_requirements.txt \
         && apt-get remove -y build-essential python-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev \
-                             libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev \
+                             libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev git \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 

--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -1,3 +1,8 @@
+# the latest released version of pip might upgrade too much libs
+# see https://github.com/pypa/pip/pull/4500/
+# the development version will upgrade only if needed
+git+https://github.com/pypa/pip.git#egg=pip
+
 # Odoo dependencies
 Babel==1.3
 Jinja2==2.7.3

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -41,6 +41,7 @@ RUN set -x; \
             zlib1g-dev \
             libfreetype6-dev \
             tcl expect \
+            git \
         && curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
         && apt-get update \
         && apt-get install -y --no-install-recommends \
@@ -52,7 +53,7 @@ RUN set -x; \
         && apt-get -y install -f --no-install-recommends \
         && pip install -U pip && pip install -r base_requirements.txt \
         && apt-get remove -y build-essential python-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev \
-                             libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev \
+                             libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev git \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -1,3 +1,8 @@
+# the latest released version of pip might upgrade too much libs
+# see https://github.com/pypa/pip/pull/4500/
+# the development version will upgrade only if needed
+git+https://github.com/pypa/pip.git#egg=pip
+
 # Odoo dependencies
 Babel==1.3
 Jinja2==2.7.3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,8 @@ Unreleased
 
 **Libraries**
 
+* Upgrade pip to the development version, to prevent unnecessary upgrades of libs
+
 **Build**
 
 **Documentation**


### PR DESCRIPTION
To prevent unnecessary upgrades of libraries. See https://github.com/pypa/pip/pull/3972