### PR TITLE
Reduce size of the 11.0 image

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -31,10 +31,10 @@ RUN set -x; \
             node-clean-css \
             node-less \
             poppler-utils \
-            python-libxslt1 \
             python3-pip \
             python3-setuptools \
             python3-renderpm \
+            libxslt1.1 \
             xfonts-75dpi \
             xfonts-base \
             tcl expect \
@@ -61,16 +61,16 @@ RUN set -x; \
         && curl -o wkhtmltox.tar.xz -SL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
         && echo '3f923f425d345940089e44c1466f6408b9619562 wkhtmltox.tar.xz' | sha1sum -c - \
         && tar xvf wkhtmltox.tar.xz \
-        && cp wkhtmltox/lib/* /usr/local/lib/ \
-        && cp wkhtmltox/bin/* /usr/local/bin/ \
-        && cp -r wkhtmltox/share/man/man1 /usr/local/share/man/ \
+        && cp --no-dereference --preserve=link wkhtmltox/lib/* /usr/local/lib/ \
+        && cp wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf \
+        && rm -rf wkhtmltox wkhtmltox.tar.xz \
         && apt-get -y install -f --no-install-recommends \
         && pip3 install -U pip && pip3 install wheel && pip3 install -r base_requirements.txt --ignore-installed \
         && apt-get remove -y build-essential gcc python3.5-dev libevent-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev git \
                              libsasl2-dev libldap2-dev libssl-dev libjpeg-dev libpng-dev zlib1g-dev \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false \
         && ln -s $(which pip3) /usr/bin/pip \
-        && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+        && rm -rf /var/lib/apt/lists/* /root/.cache/pip/*
 
 # grab gosu for easy step-down from root
  RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,13 @@
 Release History
 ---------------
 
+2.5.0.dev
++++++++++
+
+**Build**
+
+* Reduce size of the 11.0 image by cleaning and optimizing layers
+
 2.5.0 (2018-01-11)
 ++++++++++++++++++
 


### PR DESCRIPTION
* python-libxslt1 pulls Python 2.7 which takes space. It is unlikely that
we need it as we use Python 3. We need to install libxslt1.1 though
* The wkhtmltopdf archive contains a .so in the lib directory with
several symlinks pointing to the same file. By default cp will copy
several times the same file:

-rwxr-xr-x 1 root staff 45134232 Jan 11 14:23 libwkhtmltox.so
-rwxr-xr-x 1 root staff 45134232 Jan 11 14:23 libwkhtmltox.so.0
-rwxr-xr-x 1 root staff 45134232 Jan 11 14:23 libwkhtmltox.so.0.12
-rwxr-xr-x 1 root staff 45134232 Jan 11 14:23 libwkhtmltox.so.0.12.4

Instead of:

root@c384d2ebae3c:/usr/local/lib# ls -l
total 43984
lrwxrwxrwx 1 root root        22 Feb 27  2015 libwkhtmltox.so -> libwkhtmltox.so.0.12.1
lrwxrwxrwx 1 root root        22 Feb 27  2015 libwkhtmltox.so.0 -> libwkhtmltox.so.0.12.1
lrwxrwxrwx 1 root root        22 Feb 27  2015 libwkhtmltox.so.0.12 -> libwkhtmltox.so.0.12.1
-rwxr-xr-x 1 root root  45034680 Feb 27  2015 libwkhtmltox.so.0.12.1

* Remove the wkhtmltopdf archive and extracted files
* Remove the pip cache

Result:

camptocamp/odoo-project  11.0-latest  f208f44ff57e  2 minutes ago      552.2 MB
camptocamp/odoo-project  11.0-2.5.0   9a882d5b8320  About an hour ago  941.8 MB