### PR TITLE
Allow usage of a proxy for the gpg keyservers

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -58,7 +58,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+RUN gpg --keyserver pool.sks-keyservers.net --keyserver-options http-proxy=$http_proxy --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
         && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
         && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
         && gpg --verify /usr/local/bin/gosu.asc \

--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -58,12 +58,26 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --keyserver-options http-proxy=$http_proxy --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-        && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
-        && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
-        && gpg --verify /usr/local/bin/gosu.asc \
-        && rm /usr/local/bin/gosu.asc \
-        && chmod +x /usr/local/bin/gosu
+# fix intermittent gpg server error from https://github.com/tianon/gosu/issues/35
+RUN export GNUPGHOME="$(mktemp -d)" \
+    && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                               hkp://p80.pool.sks-keyservers.net:80 \
+                               keyserver.ubuntu.com \
+                               hkp://keyserver.ubuntu.com:80 \
+                               pgp.mit.edu) ; do \
+         ks_options="" && \
+         if [ -n "$http_proxy" ] ; then \
+           ks_options="--keyserver-options http-proxy=$http_proxy" ; \
+         fi \
+         && gpg --keyserver "$server" $ks_options --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+       done \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    # verify that the binary works
+    && gosu nobody true
 
 # grab dockerize for generation of the configuration file and wait on postgres
 RUN curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL \

--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /opt/odoo /var/log/odoo
 WORKDIR "/opt/odoo"
 
 COPY ./base_requirements.txt ./
+COPY ./install /install
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
@@ -57,32 +58,9 @@ RUN set -x; \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
-# grab gosu for easy step-down from root
-# fix intermittent gpg server error from https://github.com/tianon/gosu/issues/35
-RUN export GNUPGHOME="$(mktemp -d)" \
-    && for server in $(shuf -e ha.pool.sks-keyservers.net \
-                               hkp://p80.pool.sks-keyservers.net:80 \
-                               keyserver.ubuntu.com \
-                               hkp://keyserver.ubuntu.com:80 \
-                               pgp.mit.edu) ; do \
-         ks_options="" && \
-         if [ -n "$http_proxy" ] ; then \
-           ks_options="--keyserver-options http-proxy=$http_proxy" ; \
-         fi \
-         && gpg --keyserver "$server" $ks_options --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-       done \
-    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # verify that the binary works
-    && gosu nobody true
-
-# grab dockerize for generation of the configuration file and wait on postgres
-RUN curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL \
-    && echo 'a13ff2aa6937f45ccde1f29b1574744930f5c9a5 dockerize-linux-amd64-v0.6.0.tar.gz' | sha1sum -c - \
-    && tar xvfz dockerize-linux-amd64-v0.6.0.tar.gz -C /usr/local/bin && rm dockerize-linux-amd64-v0.6.0.tar.gz
+# grab gosu for easy step-down from root and dockerize to generate template and
+# wait on postgres
+RUN /install/gosu.sh && /install/dockerize.sh && rm -rf /install
 
 COPY ./src_requirements.txt ./
 COPY ./bin bin

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -73,7 +73,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* /root/.cache/pip/*
 
 # grab gosu for easy step-down from root
- RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+ RUN gpg --keyserver pool.sks-keyservers.net --keyserver-options http-proxy=$http_proxy --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
          && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
          && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
          && gpg --verify /usr/local/bin/gosu.asc \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /opt/odoo /var/log/odoo
 WORKDIR "/opt/odoo"
 
 COPY ./base_requirements.txt ./
+COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is
 # an accent in the contributor name
@@ -72,32 +73,9 @@ RUN set -x; \
         && ln -s $(which pip3) /usr/bin/pip \
         && rm -rf /var/lib/apt/lists/* /root/.cache/pip/*
 
-# grab gosu for easy step-down from root
-# fix intermittent gpg server error from https://github.com/tianon/gosu/issues/35
-RUN export GNUPGHOME="$(mktemp -d)" \
-    && for server in $(shuf -e ha.pool.sks-keyservers.net \
-                               hkp://p80.pool.sks-keyservers.net:80 \
-                               keyserver.ubuntu.com \
-                               hkp://keyserver.ubuntu.com:80 \
-                               pgp.mit.edu) ; do \
-         ks_options="" && \
-         if [ -n "$http_proxy" ] ; then \
-           ks_options="--keyserver-options http-proxy=$http_proxy" ; \
-         fi \
-         && gpg --keyserver "$server" $ks_options --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-       done \
-    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # verify that the binary works
-    && gosu nobody true
-
-# grab dockerize for generation of the configuration file and wait on postgres
-RUN curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL \
-    && echo 'a13ff2aa6937f45ccde1f29b1574744930f5c9a5 dockerize-linux-amd64-v0.6.0.tar.gz' | sha1sum -c - \
-    && tar xvfz dockerize-linux-amd64-v0.6.0.tar.gz -C /usr/local/bin && rm dockerize-linux-amd64-v0.6.0.tar.gz
+# grab gosu for easy step-down from root and dockerize to generate template and
+# wait on postgres
+RUN /install/gosu.sh && /install/dockerize.sh && rm -rf /install
 
 COPY ./src_requirements.txt ./
 COPY ./bin bin

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -73,12 +73,26 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* /root/.cache/pip/*
 
 # grab gosu for easy step-down from root
- RUN gpg --keyserver pool.sks-keyservers.net --keyserver-options http-proxy=$http_proxy --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-         && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
-         && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
-         && gpg --verify /usr/local/bin/gosu.asc \
-         && rm /usr/local/bin/gosu.asc \
-         && chmod +x /usr/local/bin/gosu
+# fix intermittent gpg server error from https://github.com/tianon/gosu/issues/35
+RUN export GNUPGHOME="$(mktemp -d)" \
+    && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                               hkp://p80.pool.sks-keyservers.net:80 \
+                               keyserver.ubuntu.com \
+                               hkp://keyserver.ubuntu.com:80 \
+                               pgp.mit.edu) ; do \
+         ks_options="" && \
+         if [ -n "$http_proxy" ] ; then \
+           ks_options="--keyserver-options http-proxy=$http_proxy" ; \
+         fi \
+         && gpg --keyserver "$server" $ks_options --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+       done \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    # verify that the binary works
+    && gosu nobody true
 
 # grab dockerize for generation of the configuration file and wait on postgres
 RUN curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -58,7 +58,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+RUN gpg --keyserver pool.sks-keyservers.net --keyserver-options http-proxy=$http_proxy --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
         && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
         && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
         && gpg --verify /usr/local/bin/gosu.asc \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -58,12 +58,26 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --keyserver-options http-proxy=$http_proxy --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-        && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
-        && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
-        && gpg --verify /usr/local/bin/gosu.asc \
-        && rm /usr/local/bin/gosu.asc \
-        && chmod +x /usr/local/bin/gosu
+# fix intermittent gpg server error from https://github.com/tianon/gosu/issues/35
+RUN export GNUPGHOME="$(mktemp -d)" \
+    && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                               hkp://p80.pool.sks-keyservers.net:80 \
+                               keyserver.ubuntu.com \
+                               hkp://keyserver.ubuntu.com:80 \
+                               pgp.mit.edu) ; do \
+         ks_options="" && \
+         if [ -n "$http_proxy" ] ; then \
+           ks_options="--keyserver-options http-proxy=$http_proxy" ; \
+         fi \
+         && gpg --keyserver "$server" $ks_options --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+       done \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    # verify that the binary works
+    && gosu nobody true
 
 # grab dockerize for generation of the configuration file and wait on postgres
 RUN curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /opt/odoo /var/log/odoo
 WORKDIR "/opt/odoo"
 
 COPY ./base_requirements.txt ./
+COPY ./install /install
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
@@ -57,32 +58,9 @@ RUN set -x; \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
-# grab gosu for easy step-down from root
-# fix intermittent gpg server error from https://github.com/tianon/gosu/issues/35
-RUN export GNUPGHOME="$(mktemp -d)" \
-    && for server in $(shuf -e ha.pool.sks-keyservers.net \
-                               hkp://p80.pool.sks-keyservers.net:80 \
-                               keyserver.ubuntu.com \
-                               hkp://keyserver.ubuntu.com:80 \
-                               pgp.mit.edu) ; do \
-         ks_options="" && \
-         if [ -n "$http_proxy" ] ; then \
-           ks_options="--keyserver-options http-proxy=$http_proxy" ; \
-         fi \
-         && gpg --keyserver "$server" $ks_options --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-       done \
-    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # verify that the binary works
-    && gosu nobody true
-
-# grab dockerize for generation of the configuration file and wait on postgres
-RUN curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL \
-    && echo 'a13ff2aa6937f45ccde1f29b1574744930f5c9a5 dockerize-linux-amd64-v0.6.0.tar.gz' | sha1sum -c - \
-    && tar xvfz dockerize-linux-amd64-v0.6.0.tar.gz -C /usr/local/bin && rm dockerize-linux-amd64-v0.6.0.tar.gz
+# grab gosu for easy step-down from root and dockerize to generate template and
+# wait on postgres
+RUN /install/gosu.sh && /install/dockerize.sh && rm -rf /install
 
 COPY ./src_requirements.txt ./
 COPY ./bin bin

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,12 +18,15 @@
 Release History
 ---------------
 
- unreleased
- ++++++++++
+Unreleased
+++++++++++
 
- **Features and Improvements**
+**Features and Improvements**
 
- * Add Script to set report.url if provided.
+* Add Script to set report.url if provided.
+* The http_proxy environment variable will be honored by 'gpg' when reaching the
+  key for the gosu key.
+
 
 2.5.1 (2018-01-11)
 ++++++++++++++++++

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 	$(eval TMP := $(shell mktemp -u))
 	cp -r $(VERSION) $(TMP)
 	cp -r bin/ $(TMP)
+	cp -r install/ $(TMP)
 	cp -r start-entrypoint.d/ $(TMP)
 	cp -r before-migrate-entrypoint.d/ $(TMP)
 	docker build --no-cache -t $(IMAGE_LATEST) $(TMP)

--- a/install/dockerize.sh
+++ b/install/dockerize.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eo pipefail
+
+curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL
+echo 'a13ff2aa6937f45ccde1f29b1574744930f5c9a5 dockerize-linux-amd64-v0.6.0.tar.gz' | sha1sum -c -
+tar xvfz dockerize-linux-amd64-v0.6.0.tar.gz -C /usr/local/bin && rm dockerize-linux-amd64-v0.6.0.tar.gz

--- a/install/gosu.sh
+++ b/install/gosu.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eo pipefail
+
+# fix intermittent gpg server error from https://github.com/tianon/gosu/issues/35
+export GNUPGHOME="$(mktemp -d)"
+for server in $(shuf -e ha.pool.sks-keyservers.net \
+                        hkp://p80.pool.sks-keyservers.net:80 \
+                        keyserver.ubuntu.com \
+                        hkp://keyserver.ubuntu.com:80 \
+                        pgp.mit.edu)
+do
+  ks_options=""
+  # $http_proxy is an environment variable which is usually lowcase, a gpg quirk
+  if [ -n "$http_proxy" ]
+  then
+    ks_options="--keyserver-options http-proxy=$http_proxy"
+  fi
+  gpg --keyserver "$server" $ks_options --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || :
+done
+curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)"
+curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc"
+gpg --verify /usr/local/bin/gosu.asc
+rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc
+chmod +x /usr/local/bin/gosu
+# verify that the binary works
+gosu nobody true


### PR DESCRIPTION
If the http_proxy environment variable is set, it will be used for
reaching the gpg key server. When the variable is empty, the behavior is
the same than before (no proxy).