### PR TITLE
Add script to set report.url

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,13 @@
 Release History
 ---------------
 
+ unreleased
+ ++++++++++
+
+ **Features and Improvements**
+
+ * Add Script to set report.url if provided.
+
 2.5.1 (2018-01-11)
 ++++++++++++++++++
 

--- a/start-entrypoint.d/001_set_report_url
+++ b/start-entrypoint.d/001_set_report_url
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+DOMAIN="${ODOO_REPORT_URL}"
+
+if [ -n "$DOMAIN" ]; then
+
+  if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
+  then
+      echo "Database does not exist, ignoring script"
+      exit 0
+  fi
+
+  echo "Setting Report URL to domain ${DOMAIN}"
+  psql --quiet << EOF
+
+  WITH update_param AS (
+    UPDATE ir_config_parameter
+    SET value = '${DOMAIN}'
+    WHERE key = 'report.url'
+    RETURNING *
+  )
+  INSERT INTO ir_config_parameter
+  (value, key, create_uid, write_uid, create_date, write_date)
+  SELECT '${DOMAIN}', 'report.url', 1, 1, now(), now()
+  WHERE NOT EXISTS (SELECT * FROM update_param);
+
+EOF
+fi


### PR DESCRIPTION
This script sets the report.url property to guide wktmltopdf to the correct location. If nothing is given the web.base.url is used. Thats why there is no default value.