### PR TITLE
Upgrade setuptools

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -52,7 +52,7 @@ RUN set -x; \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \
         && apt-get -y install -f --no-install-recommends \
-        && pip install -U pip && pip install -r base_requirements.txt \
+        && pip install -U pip setuptools && pip install -r base_requirements.txt \
         && apt-get remove -y build-essential python-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev \
                              libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev git \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -66,7 +66,7 @@ RUN set -x; \
         && cp wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf \
         && rm -rf wkhtmltox wkhtmltox.tar.xz \
         && apt-get -y install -f --no-install-recommends \
-        && pip3 install -U pip && pip3 install wheel && pip3 install -r base_requirements.txt --ignore-installed \
+        && pip3 install -U pip setuptools && pip3 install wheel && pip3 install -r base_requirements.txt --ignore-installed \
         && apt-get remove -y build-essential gcc python3.5-dev libevent-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev git \
                              libsasl2-dev libldap2-dev libssl-dev libjpeg-dev libpng-dev zlib1g-dev \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -52,7 +52,7 @@ RUN set -x; \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \
         && apt-get -y install -f --no-install-recommends \
-        && pip install -U pip && pip install -r base_requirements.txt \
+        && pip install -U pip setuptools && pip install -r base_requirements.txt \
         && apt-get remove -y build-essential python-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev \
                              libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev git \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,10 @@ Unreleased
 * The http_proxy environment variable will be honored by 'gpg' when reaching the
   key for the gosu key.
 
+**Build**
+
+* Upgrade setuptools, otherwise the pip installs fail with
+  NameError: name 'platform_system' is not defined
 
 2.5.1 (2018-01-11)
 ++++++++++++++++++


### PR DESCRIPTION
The installed version of setuptools fail with:

```
Traceback (most recent call last):
  File "/usr/local/bin/odoo.py", line 4, in <module>
    __import__('pkg_resources').require('odoo==9.0c')
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2876, in <module>
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 449, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 745, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 645, in resolve
    requirements.extend(dist.requires(req.extras)[::-1])
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2401, in requires
    dm = self._dep_map
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2597, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2630, in _compute_dependencies
    common = frozenset(reqs_for_extra(None))
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2627, in reqs_for_extra
    if req.marker_fn(override={'extra':extra}):
  File "/usr/lib/python2.7/dist-packages/_markerlib/markers.py", line 113, in marker_fn
    return eval(compiled_marker, environment)
  File "<environment marker>", line 1, in <module>
NameError: name 'platform_system' is not defined
```