### PR TITLE
Fix permission issue when installing runtests db

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -32,7 +32,7 @@ fi
 DB_NAME_TEST=${DB_NAME}_test
 
 PGPASSWORD=$DB_PASSWORD createdb -h $DB_HOST -U $DB_USER -O $DB_USER ${DB_NAME_TEST}
-"${ODOO_BIN_PATH}" --stop-after-init --workers=0 --database $DB_NAME_TEST --log-level=warn --without-demo="" -i ${LOCAL_ADDONS}
+odoo --stop-after-init --workers=0 --database $DB_NAME_TEST --log-level=warn --without-demo="" -i ${LOCAL_ADDONS}
 coverage run --source="${LOCAL_SRC_DIR}" "${ODOO_BIN_PATH}" --stop-after-init --workers=0 --database $DB_NAME_TEST --test-enable --log-level=test --log-handler=":INFO" -u ${LOCAL_ADDONS}
 PGPASSWORD=$DB_PASSWORD dropdb -h $DB_HOST -U $DB_USER ${DB_NAME_TEST}
 


### PR DESCRIPTION
By consistency, in the commit 0c58332 I changed the path to the odoo-bin
script in both places it was used.
However, as long as 'coverage run' accepts a file which doesn't to be
executable, the first call is executed. We could call python2 or python3
on ${ODOO_BIN_PATH}, but the "odoo" script is there for that. So let's
keep "odoo" for the install and use the "odoo-bin" only for 'coverage
run' where it's required.

For the record, the 'odoo-bin' script is eXecutable in the git
repository, but in some cases we optimize the build of the image by
downloading a tar, and it seems the x flag is absent there.