### PR TITLE
Always set env var `ODOO_REPORT_URL`

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -85,6 +85,7 @@ ENV ODOO_VERSION=10.0 \
     DB_USER=odoo \
     DB_PASSWORD=odoo \
     ODOO_BASE_URL=http://localhost:8069 \
+    ODOO_REPORT_URL=http://localhost:8069 \
     DEMO=False \
     ADDONS_PATH=/opt/odoo/local-src,/opt/odoo/src/addons \
     OPENERP_SERVER=/opt/odoo/etc/odoo.cfg

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -100,6 +100,7 @@ ENV ODOO_VERSION=11.0 \
     DB_USER=odoo \
     DB_PASSWORD=odoo \
     ODOO_BASE_URL=http://localhost:8069 \
+    ODOO_REPORT_URL=http://localhost:8069 \
     ODOO_DATA_PATH=/opt/odoo/data \
     DEMO=False \
     ADDONS_PATH=/opt/odoo/local-src,/opt/odoo/src/addons \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -86,6 +86,7 @@ ENV ODOO_VERSION=9.0 \
     DB_USER=odoo \
     DB_PASSWORD=odoo \
     ODOO_BASE_URL=http://localhost:8069 \
+    ODOO_REPORT_URL=http://localhost:8069 \
     DEMO=False \
     ADDONS_PATH=/opt/odoo/local-src,/opt/odoo/src/addons \
     OPENERP_SERVER=/opt/odoo/etc/odoo.cfg


### PR DESCRIPTION
By default report.url fallbacks to web.base.url.

As the reports are very workers consuming (needs 3 workers),
we thought that it would be better if they hit the public url
to round robin on the hosts if you have more than one.

This is true but many times does not work because of networks issues,
caching issues, etc (like on minions for instance).

With this change we force it always to be `localhost:8069`.