### PR TITLE
Fix travis pip install

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -53,7 +53,7 @@ RUN set -x; \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \
         && apt-get -y install -f --no-install-recommends \
-        && pip install -U pip setuptools && pip install -r base_requirements.txt \
+        && pip install -U pip setuptools && python -m pip install -r base_requirements.txt \
         && apt-get remove -y build-essential python-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev \
                              libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev git \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -67,7 +67,7 @@ RUN set -x; \
         && cp wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf \
         && rm -rf wkhtmltox wkhtmltox.tar.xz \
         && apt-get -y install -f --no-install-recommends \
-        && pip3 install -U pip setuptools && pip3 install wheel && pip3 install -r base_requirements.txt --ignore-installed \
+        && pip3 install -U pip setuptools && python3 -m pip install wheel && python3 -m pip install -r base_requirements.txt --ignore-installed \
         && apt-get remove -y build-essential gcc python3.5-dev libevent-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev git \
                              libsasl2-dev libldap2-dev libssl-dev libjpeg-dev libpng-dev zlib1g-dev \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -53,7 +53,7 @@ RUN set -x; \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \
         && apt-get -y install -f --no-install-recommends \
-        && pip install -U pip setuptools && pip install -r base_requirements.txt \
+        && pip install -U pip setuptools && python -m pip install -r base_requirements.txt \
         && apt-get remove -y build-essential python-dev libfreetype6-dev libpq-dev libxml2-dev libxslt1-dev \
                              libsasl2-dev libldap2-dev libssl-dev libjpeg-dev zlib1g-dev libfreetype6-dev git \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \


### PR DESCRIPTION
Bypass the wrapper to call pip with `python -m pip` 

This is an attempt to fix travis error:

```
+ pip3 install -U pip setuptools
Collecting pip
  Downloading https://files.pythonhosted.org/packages/5f/25/e52d3f31441505a5f3af41213346e5b6c221c9e086a166f3703d2ddaf940/pip-18.0-py2.py3-none-any.whl (1.3MB)
Collecting setuptools
  Downloading https://files.pythonhosted.org/packages/ff/f4/385715ccc461885f3cedf57a41ae3c12b5fec3f35cce4c8706b1a112a133/setuptools-40.0.0-py2.py3-none-any.whl (567kB)
Installing collected packages: pip, setuptools
  Found existing installation: pip 9.0.1
    Not uninstalling pip at /usr/lib/python3/dist-packages, outside environment /usr
  Found existing installation: setuptools 33.1.1
    Not uninstalling setuptools at /usr/lib/python3/dist-packages, outside environment /usr
Successfully installed pip-18.0 setuptools-40.0.0
+ pip3 install wheel
Traceback (most recent call last):
  File "/usr/bin/pip3", line 9, in <module>
    from pip import main
ImportError: cannot import name 'main'
```