### PR TITLE
Upgrade pycryptodome to 3.6.6

### DIFF
--- a/10.0/extra_requirements.txt
+++ b/10.0/extra_requirements.txt
@@ -40,7 +40,7 @@ jmespath==0.9.3
 pdfminer.six==20170720
 pyasn1==0.4.3
 pycparser==2.18
-pycryptodome==3.6.3
+pycryptodome==3.6.6
 PyNaCl==1.2.1
 PyPDF2==1.26.0
 PySimpleSOAP==1.16.2

--- a/11.0/extra_requirements.txt
+++ b/11.0/extra_requirements.txt
@@ -37,7 +37,7 @@ multidict==4.3.1
 pdfminer.six==20170720
 pyasn1==0.4.3
 pycparser==2.18
-pycryptodome==3.6.3
+pycryptodome==3.6.6
 PyNaCl==1.2.1
 pytesseract==0.2.2
 regex==2018.6.9

--- a/9.0/extra_requirements.txt
+++ b/9.0/extra_requirements.txt
@@ -41,7 +41,7 @@ jmespath==0.9.3
 pdfminer.six==20170720
 pyasn1==0.4.3
 pycparser==2.18
-pycryptodome==3.6.3
+pycryptodome==3.6.6
 PyNaCl==1.2.1
 PyPDF2==1.26.0
 PySimpleSOAP==1.16.2


### PR DESCRIPTION
PyCryptodome before 3.6.6 has an integer overflow in the data_len
variable in AESNI.c, related to the AESNI_encrypt and AESNI_decrypt
functions, leading to the mishandling of messages shorter than 16 bytes.