### PR TITLE
Launch tests only once

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -81,7 +81,6 @@ else
 fi
 echo "🔧🔧 Install local-src modules 🔧🔧"
 odoo --stop-after-init --workers=0 --database $DB_NAME_TEST --log-level=warn --without-demo="" -i ${LOCAL_ADDONS}
-odoo --stop-after-init --workers=0 --database $DB_NAME_TEST --test-enable --log-level=test --log-handler=":INFO" -u ${LOCAL_ADDONS}
 coverage run --source="${LOCAL_SRC_DIR}" "${ODOO_BIN_PATH}" --stop-after-init --workers=0 --database $DB_NAME_TEST --test-enable --log-level=test --log-handler=":INFO" -u ${LOCAL_ADDONS}
 dropdb ${DB_NAME_TEST}
 


### PR DESCRIPTION
Launch of tests is already included in coverage run line.

Currently tests are run twice.