### PR TITLE
Unfreeze pluggy version

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -67,6 +67,7 @@ anthem==0.12.0
 # test / lint
 flake8
 pytest
+pluggy
 pytest-odoo
 coverage
 pytest-cov
@@ -84,7 +85,6 @@ mccabe==0.6.1
 more-itertools==4.2.0
 pathtools==0.1.2
 pexpect==4.6.0
-pluggy==0.6.0
 ptyprocess==0.5.2
 py==1.5.3
 pycodestyle==2.3.1

--- a/11.0/base_requirements.txt
+++ b/11.0/base_requirements.txt
@@ -68,6 +68,7 @@ anthem==0.12.0
 # test / lint
 flake8
 pytest
+pluggy
 coverage
 pytest-odoo
 pytest-cov
@@ -84,7 +85,6 @@ more-itertools==4.2.0
 pathtools==0.1.2
 pbr==4.0.4
 pexpect==4.6.0
-pluggy==0.6.0
 ptyprocess==0.5.2
 py==1.5.3
 pycodestyle==2.3.1

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -59,6 +59,7 @@ anthem==0.12.0
 # test / lint
 flake8
 pytest
+pluggy
 coverage
 pytest-odoo
 pytest-cov
@@ -75,7 +76,6 @@ more-itertools==4.2.0
 pathtools==0.1.2
 pbr==4.0.4
 pexpect==4.6.0
-pluggy==0.6.0
 ptyprocess==0.5.2
 py==1.5.3
 pycodestyle==2.3.1


### PR DESCRIPTION
pytest 2.9 requires pluggy>=0.7

By fixing pluggy we broke pytest.

This fixes failure on python TypeError: __call__() got an unexpected keyword argument 'warn_on_impl'