### PR TITLE
Revert "Temporary fix test waiting Odoo release 12.0"

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,13 +21,7 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
-# Temporary fix test waiting Odoo release 12.0
-if [ "$VERSION" = "12.0" ]
-then
-    ODOO_URL="https://github.com/odoo/odoo/archive/master.tar.gz"
-else
-    ODOO_URL="https://github.com/odoo/odoo/archive/${VERSION}.tar.gz"
-fi
+ODOO_URL="https://github.com/odoo/odoo/archive/${VERSION}.tar.gz"
 
 TMP=$(mktemp -d)
 echo "Working in $TMP"
@@ -68,13 +62,7 @@ echo '>>> Downloading Odoo src'
 rm -rf "$TMP/odoo/src"
 wget -nv -O /tmp/odoo.tar.gz "$ODOO_URL"
 tar xfz /tmp/odoo.tar.gz -C odoo/
-# Temporary fix test waiting Odoo release 12.0
-if [ "$VERSION" = "12.0" ]
-then
-    mv "odoo/odoo-master" odoo/src
-else
-    mv "odoo/odoo-$VERSION" odoo/src
-fi
+mv "odoo/odoo-$VERSION" odoo/src
 
 echo '>>> Run test for base image'
 sed "s|FROM .*|FROM ${IMAGE_LATEST}|" -i odoo/Dockerfile


### PR DESCRIPTION
This reverts commit 484f005480f4d66d36a8856db2c6a2b9ccff3f2f.

This commit was added because Odoo did not have a 12.0 branch yet.
Now that it is there, it must be reverted otherwise the 12.0 image is tested against master.