### PR TITLE
Remove bad copy of extra_requirements in Dockerfile

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER Camptocamp
 RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
-COPY ./extra_requirements.txt /odoo
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER Camptocamp
 RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
-COPY ./extra_requirements.txt /odoo
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER Camptocamp
 RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
-COPY ./extra_requirements.txt /odoo
 COPY ./install /install
 
 # build and dev packages

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,10 @@ Unreleased
 
 .. **Bugfixes**
 
+* Remove bad copy of extra_requirements in Dockerfile
+
+  * Must be done only in batteries flavor (see Dockerfile-batteries)
+
 .. **Libraries**
 
 .. **Build**


### PR DESCRIPTION
Must be done only in batteries flavor (see Dockerfile-batteries):
https://github.com/camptocamp/docker-odoo-project/blob/master/common/Dockerfile-batteries#L4