### PR TITLE
runtests: allow to use a DB template

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,13 @@ docker-compose run --rm [-e CREATE_DB_CACHE=true] [-e LOAD_DB_CACHE=false] [-e S
 ```
 
 
-This is not the day-to-day tool for running the tests as a developer.
+This is not the day-to-day tool for running the tests as a developer but you can use it to simulate tests as on Travis.
+
+To save time you can reuse an existing DB (ready with few core modules installed) by passing `DB_TEST_TEMPLATE=db_name`:
+
+```
+docker-compose run --rm -e DB_TEST_TEMPLATE=mytest_base odoo runtests
+```
 
 ### pytests
 

--- a/bin/runtests
+++ b/bin/runtests
@@ -52,7 +52,16 @@ DB_NAME_TEST=${DB_NAME}_test
 
 
 echo "Create database"
-createdb -O $DB_USER ${DB_NAME_TEST}
+if [[ ! -z "$DB_TEST_TEMPLATE" ]];
+then
+  # When running tests locally you might want to not start from scratch every time.
+  # Tip: create the template w/ only `base` or few core modules installed
+  # to still replicate more or less the same behavior as on travis.
+  echo "using template: ${DB_TEST_TEMPLATE}"
+  createdb -O $DB_USER ${DB_NAME_TEST} -T ${DB_TEST_TEMPLATE}
+else
+  createdb -O $DB_USER ${DB_NAME_TEST}
+fi
 
 if [[ ! -z "$SUBS_MD5" ]]; then
     CACHED_DUMP="$CACHE_DIR/odoo_test_$SUBS_MD5.dmp"


### PR DESCRIPTION
When running tests locally you might want to simulate tests as on Travis
and at the same time to not start from scratch every time
because your time IS important ;)

You can now run the tests like:

`doco run --rm -e DB_TEST_TEMPLATE=foo odoo runtests`