### PR TITLE
Fix missing variable with docker-compose exec

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -15,6 +15,17 @@ export PGUSER=${DB_USER}
 export PGPASSWORD=${DB_PASSWORD}
 export PGDATABASE=${DB_NAME}
 
+# As docker-compose exec do not launch the entrypoint
+# init PG variable into .bashrc so it will be initialized
+# when doing docker-compose exec odoo gosu odoo bash
+echo "
+export PGHOST=${DB_HOST}
+export PGPORT=${DB_PORT}
+export PGUSER=${DB_USER}
+export PGPASSWORD=${DB_PASSWORD}
+export PGDATABASE=${DB_NAME}
+" >> /home/odoo/.bashrc
+
 # Accepted values for DEMO: True / False
 # Odoo use a reverse boolean for the demo, which is not handy,
 # that's why we propose DEMO which exports WITHOUT_DEMO used in


### PR DESCRIPTION
When using docker-compose exec the entrypoint is not executed and so
the export of psql variable is not done.
This change will modify the bashrc configuration so if you do a
docker-compose exec odoo gosu odoo bash
you will have the right psql variable

@guewen @hpar

The alternative solution will be to use psql vars into environment file instead of custom one; but this is a broken change