### PR TITLE
Add script to install wkhtml 0.12.5.1

### DIFF
--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -35,7 +35,7 @@ RUN set -x; \
         && /install/package_odoo_11.0_12.0.sh \
         && /install/setup-pip.sh \
         && /install/postgres.sh \
-        && /install/wkhtml_12_4.sh \
+        && /install/wkhtml_12_5.sh \
         && /install/dev_package.sh \
         && python3 -m pip install --force-reinstall pip setuptools \
         && pip3 install -r /odoo/base_requirements.txt --ignore-installed \

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,6 +35,7 @@ Unreleased
 
 * Bump `Jinja2` version to 2.10.1
 * Bump `urllib3` version to 1.24.2
+* Bump `wkhtmltopdf` version to 0.12.5.1 (for odoo 12 only)
 
 **Build**
 

--- a/install/wkhtml_12_5.sh
+++ b/install/wkhtml_12_5.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl -o wkhtmltox.deb -SL https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
+echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c -
+dpkg --force-depends -i wkhtmltox.deb


### PR DESCRIPTION
## ISSUE

Above the result with 0.12.4

Probably broken with last odoo commits.

![wkhtml](https://user-images.githubusercontent.com/1853434/63843931-845d8480-c987-11e9-8af8-582e991f3e5b.png)

Below with 0.12.5.1

## CONTENT

- [X]  set wkhtmltopdf new version



