### PR TITLE
Bump libraries to fix security alerts

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==0.23
 Pillow==3.4.1
 Python-Chart==1.39
 PyYAML==4.2b4
-Werkzeug==0.11.11
+Werkzeug==0.16.0
 chardet==3.0.4
 colorama==0.3.9
 decorator==4.0.10

--- a/11.0/base_requirements.txt
+++ b/11.0/base_requirements.txt
@@ -37,7 +37,7 @@ six==1.10.0
 suds-jurko==0.6
 vatnumber==1.2
 vobject==0.9.3
-Werkzeug==0.11.15
+Werkzeug==0.16.0
 XlsxWriter==0.9.3
 xlwt==1.3.*
 xlrd==1.0.0

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -34,7 +34,7 @@ requests==2.20.0
 suds-jurko==0.6
 vatnumber==1.2
 vobject==0.9.3
-Werkzeug==0.11.15
+Werkzeug==0.16.0
 XlsxWriter==0.9.3
 xlwt==1.3.*
 xlrd==1.0.0

--- a/13.0/base_requirements.txt
+++ b/13.0/base_requirements.txt
@@ -35,7 +35,7 @@ requests==2.20.0
 zeep==3.1.0
 vatnumber==1.2
 vobject==0.9.3
-Werkzeug==0.14.1
+Werkzeug==0.16.0
 XlsxWriter==0.9.3
 xlwt==1.3.*
 xlrd==1.0.0

--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -1,12 +1,12 @@
 # Odoo dependencies
 Babel==1.3
-Jinja2==2.7.3
+Jinja2==2.10.1
 Mako==1.0.0
 MarkupSafe==0.23
-Pillow==2.5.1
+Pillow==3.3.2
 Python-Chart==1.39
-PyYAML==3.13
-Werkzeug==0.9.6
+PyYAML==4.2b1
+Werkzeug==0.16.0
 argparse==1.2.1
 decorator==3.4.0
 docutils==0.12
@@ -33,7 +33,7 @@ pytz==2014.4
 pyusb==1.0.0b1
 qrcode==5.0.1
 reportlab==3.1.44
-requests==2.18.0
+requests==2.20.0
 simplejson==3.5.3
 six==1.10.0
 unittest2==0.5.1

--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -1,12 +1,12 @@
 # Odoo dependencies
 Babel==1.3
-Jinja2==2.7.3
+Jinja2==2.10.1
 Mako==1.0.0
 MarkupSafe==0.23
-Pillow==2.5.1
+Pillow==3.3.2
 Python-Chart==1.39
-PyYAML==3.13
-Werkzeug==0.9.6
+PyYAML==4.2b1
+Werkzeug==0.16.0
 argparse==1.2.1
 decorator==3.4.0
 docutils==0.12
@@ -33,7 +33,7 @@ pytz==2014.4
 pyusb==1.0.0b1
 qrcode==5.0.1
 reportlab==3.1.44
-requests==2.18.0
+requests==2.20.0
 simplejson==3.5.3
 six==1.10.0
 unittest2==0.5.1

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==0.23
 Pillow==3.4.2
 Python-Chart==1.39
 PyYAML==4.2b4
-Werkzeug==0.11.11
+Werkzeug==0.16.0
 chardet==3.0.4
 colorama==0.3.9
 decorator==4.0.10

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,8 @@ Unreleased
 * Bump `Jinja2` version to 2.10.1
 * Bump `urllib3` version to 1.24.2
 * Bump `wkhtmltopdf` version to 0.12.5.1 (for odoo 12 only)
+* Bump `werkzeug` version to 0.16.0
+* Bump various libraries to get rid of security alerts (v7+8 only)
 
 **Build**
 


### PR DESCRIPTION
* Bump `werkzeug` to 0.16.0
* Bump several libraries (v7+8 only)