### PR TITLE
[7.0] Werkzeug version 0.16.0 -> 0.9.6 to avoid Bad file descriptor Error

### DIFF
--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==0.23
 Pillow==3.4.2
 Python-Chart==1.39
 PyYAML==4.2b1
-Werkzeug==0.16.0
+Werkzeug==0.9.6
 argparse==1.2.1
 decorator==3.4.0
 docutils==0.12


### PR DESCRIPTION
To avoid this error in 7.0
```
2019-11-05 10:25:48,202 313 ERROR ? openerp.service.workers: Worker (313) Exception occured, exiting...
Traceback (most recent call last):
  File "/odoo/src/openerp/service/workers.py", line 302, in run
    self.start()
  File "/odoo/src/openerp/service/workers.py", line 344, in start
    self.server = WorkerBaseWSGIServer(self.multi.app)
  File "/odoo/src/openerp/service/workers.py", line 350, in __init__
    werkzeug.serving.BaseWSGIServer.__init__(self, "1", "1", app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 705, in __init__
    self.port = self.socket.getsockname()[1]
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
  File "/usr/lib/python2.7/socket.py", line 170, in _dummy
    raise error(EBADF, 'Bad file descriptor')
error: [Errno 9] Bad file descriptor
```