### PR TITLE
Fix Pillow issue in v8

### DIFF
--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -3,7 +3,7 @@ Babel==1.3
 Jinja2==2.10.1
 Mako==1.0.0
 MarkupSafe==0.23
-Pillow==6.2.0
+Pillow==3.4.2
 Python-Chart==1.39
 PyYAML==4.2b1
 Werkzeug==0.16.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,8 +38,8 @@ Unreleased
 * Bump `wkhtmltopdf` version to 0.12.5.1 (for odoo 12 only)
 * Bump `werkzeug` version to 0.16.0
 * Bump various libraries to get rid of security alerts (v7+8 only)
-* Bump `Pillow` version to 6.2.0 (v8-13)
-* Bump `Pillow` version to 3.4.2 (v7)
+* Bump `Pillow` version to 6.2.0 (v9-13)
+* Bump `Pillow` version to 3.4.2 (v7-8)
 * Bump `anthem` version to 0.13.0
 
 **Build**


### PR DESCRIPTION
Downgrade Pillow for Odoo V8 to avoid errors like : 
`ParseError: "cannot write mode RGBA as JPEG"`