### PR TITLE
Fix Werkzeug issue in V8

### DIFF
--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==0.23
 Pillow==3.4.2
 Python-Chart==1.39
 PyYAML==4.2b1
-Werkzeug==0.16.0
+Werkzeug==0.9.6
 argparse==1.2.1
 decorator==3.4.0
 docutils==0.12

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,7 +36,8 @@ Unreleased
 * Bump `Jinja2` version to 2.10.1
 * Bump `urllib3` version to 1.24.2
 * Bump `wkhtmltopdf` version to 0.12.5.1 (for odoo 12 only)
-* Bump `werkzeug` version to 0.16.0
+* Bump `werkzeug` version to 0.16.0 (v9-13)
+* Bump `werkzeug` version to 0.9.6 (v7-8)
 * Bump various libraries to get rid of security alerts (v7+8 only)
 * Bump `Pillow` version to 6.2.0 (v9-13)
 * Bump `Pillow` version to 3.4.2 (v7-8)


### PR DESCRIPTION
Downgrade `werkzeug` version to avoid errors like
`error: [Errno 9] Bad file descriptor`