### PR TITLE
Fix coverage wrongly moved

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -52,8 +52,6 @@ COPY ./templates /templates
 COPY ./before-migrate-entrypoint.d /before-migrate-entrypoint.d
 COPY ./start-entrypoint.d /start-entrypoint.d
 COPY ./MANIFEST.in /odoo
-# Place coveragerc in workdir where coverage will be launched from
-COPY ./.coveragerc /
 
 VOLUME ["/data/odoo", "/var/log/odoo"]
 


### PR DESCRIPTION
It is not done in Versions 12 & 13.
Tested locally with:
```
make VERSION=11.0
make VERSION=11.0 test
```
