### PR TITLE
Fix missing .coveragerc for v11-12-13

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,6 +28,7 @@ Unreleased
 
 * Pin `setuptools<45` and other dependencies to ensure Python 2 support in Odoo<=10
 * Fix deprecated download links for wkhtmltopdf
+* Include `.coveragerc` for all versions
 
 **Libraries**
 

--- a/common/Dockerfile-batteries
+++ b/common/Dockerfile-batteries
@@ -2,6 +2,7 @@ MAINTAINER Camptocamp
 
 WORKDIR "/odoo"
 COPY ./extra_requirements.txt ./
+COPY ./.coveragerc ./
 
 # Install extra requirement
 RUN set -x; \

--- a/common/Dockerfile-onbuild
+++ b/common/Dockerfile-onbuild
@@ -1,5 +1,7 @@
 MAINTAINER Camptocamp
 
+COPY ./.coveragerc /odoo/
+
 # intermediate images should help speed up builds when only local-src, or only
 # external-src changes
 ONBUILD COPY ./src /odoo/src


### PR DESCRIPTION
Not sure if we should remove the lines (or update them) for v < 11