### PR TITLE
Build fixes (python libraries + wkhtmltopdf)

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip setuptools \
+        && pip install -U pip "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip setuptools \
+        && pip install -U pip "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -55,3 +55,22 @@ pytest-odoo
 coverage
 pytest-cov
 watchdog
+
+# Library dependency
+argh==0.26.2
+atomicwrites==1.1.5
+attrs==18.1.0
+beautifulsoup4==4.6.0
+configparser==3.5.0
+enum34==1.1.6
+funcsigs==1.0.2
+mccabe==0.6.1
+more-itertools==4.2.0
+pathtools==0.1.2
+pexpect==4.6.0
+ptyprocess==0.5.2
+py==1.5.3
+pycodestyle==2.3.1
+pyflakes==1.6.0
+unicodecsv==0.14.1
+wrapt==1.10.11

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip setuptools \
+        && pip install -U pip "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -55,3 +55,22 @@ pytest-odoo
 coverage
 pytest-cov
 watchdog
+
+# Library dependency
+argh==0.26.2
+atomicwrites==1.1.5
+attrs==18.1.0
+beautifulsoup4==4.6.0
+configparser==3.5.0
+enum34==1.1.6
+funcsigs==1.0.2
+mccabe==0.6.1
+more-itertools==4.2.0
+pathtools==0.1.2
+pexpect==4.6.0
+ptyprocess==0.5.2
+py==1.5.3
+pycodestyle==2.3.1
+pyflakes==1.6.0
+unicodecsv==0.14.1
+wrapt==1.10.11

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip setuptools \
+        && pip install -U pip "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -62,3 +62,22 @@ pytest-odoo
 coverage
 pytest-cov
 watchdog
+
+# Library dependency
+argh==0.26.2
+atomicwrites==1.1.5
+attrs==18.1.0
+beautifulsoup4==4.6.0
+configparser==3.5.0
+enum34==1.1.6
+funcsigs==1.0.2
+mccabe==0.6.1
+more-itertools==4.2.0
+pathtools==0.1.2
+pexpect==4.6.0
+ptyprocess==0.5.2
+py==1.5.3
+pycodestyle==2.3.1
+pyflakes==1.6.0
+unicodecsv==0.14.1
+wrapt==1.10.11

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,7 @@ Unreleased
 **Bugfixes**
 
 * Pin `setuptools<45` and other dependencies to ensure Python 2 support in Odoo<=10
+* Fix deprecated download links for wkhtmltopdf
 
 **Libraries**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,8 @@ Unreleased
 
 **Bugfixes**
 
+* Pin `setuptools<45` and other dependencies to ensure Python 2 support in Odoo<=10
+
 **Libraries**
 
 **Build**

--- a/install/wkhtml_12_5.sh
+++ b/install/wkhtml_12_5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-curl -o wkhtmltox.deb -SL https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
+curl -o wkhtmltox.deb -SL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
 echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c -
 dpkg --force-depends -i wkhtmltox.deb

--- a/install/wkhtml_12_5_1.sh
+++ b/install/wkhtml_12_5_1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-curl -o wkhtmltox.deb -SL https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
+curl -o wkhtmltox.deb -SL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb
 echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c -
 dpkg --force-depends -i wkhtmltox.deb


### PR DESCRIPTION
* Pin setuptools and dependencies to ensure Python 2 support in Odoo<=10
* Fix deprecated download links for wkhtmltopdf

Fixes #128 