### PR TITLE
Bump Pillow to fix security issue

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -3,7 +3,7 @@ Babel==2.3.4
 Jinja2==2.10.1
 Mako==1.0.4
 MarkupSafe==0.23
-Pillow==6.2.0
+Pillow==6.2.2
 Python-Chart==1.39
 PyYAML==4.2b4
 Werkzeug==0.16.0

--- a/11.0/base_requirements.txt
+++ b/11.0/base_requirements.txt
@@ -18,7 +18,7 @@ mock==2.0.0
 num2words==0.5.4
 ofxparse==0.16
 passlib==1.6.5
-Pillow==6.2.0
+Pillow==6.2.2
 psutil==5.7.0
 psycopg2==2.7.3.1
 pydot==1.2.3

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -17,7 +17,7 @@ mock==2.0.0
 num2words==0.5.4
 ofxparse==0.16
 passlib==1.6.5
-Pillow==6.2.0
+Pillow==6.2.2
 psutil==5.7.0; sys_platform != 'win32'
 psycopg2==2.7.3.1; sys_platform != 'win32'
 pydot==1.2.3

--- a/13.0/base_requirements.txt
+++ b/13.0/base_requirements.txt
@@ -17,7 +17,7 @@ mock==2.0.0
 num2words==0.5.6
 ofxparse==0.16
 passlib==1.6.5
-Pillow==6.2.0
+Pillow==6.2.2
 polib==1.1.0
 psutil==5.7.0; sys_platform != 'win32'
 psycopg2==2.7.3.1; sys_platform != 'win32'

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -3,7 +3,7 @@ Babel==2.3.4
 Jinja2==2.10.1
 Mako==1.0.4
 MarkupSafe==0.23
-Pillow==6.2.0
+Pillow==6.2.2
 Python-Chart==1.39
 PyYAML==4.2b4
 Werkzeug==0.16.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,6 +32,7 @@ Unreleased
 **Libraries**
 
 * Bump `psutil` version to 5.7.0
+* Bump `Pillow` version to 6.2.2 (v9-13)
 
 **Build**
 


### PR DESCRIPTION
Bump `Pillow` to version 6.2.2 to fix CVE-2019-19911 and CVE-2020-5313

Requirements for Odoo v7-8 cannot be updated as they are too old to handle new version of `Pillow` library