### PR TITLE
shell and --help bypass entrypoints

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,10 @@ Unreleased
 **Features and Improvements**
 
 * disable pip version checks (required network access, can timeout)
+* Bypass migration when using:
+
+    docker-compose run --rm odoo odoo shell [...]
+    docker-compose run --rm odoo odoo [...] --help [...]
 
 **Bugfixes**
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ value, the configuration parameters will be left unchanged.
 `MIGRATE` can be `True` or `False` and determines whether migration tool
 marabunta will be launched. By default migration will be launched.
 
+Migration is *not* launched when using:
+
+```
+    docker-compose run --rm odoo odoo shell [...]
+    docker-compose run --rm odoo odoo [...] --help [...]
+```
+
 ### MARABUNTA_MODE
 
 In [Marabunta](https://github.com/camptocamp/marabunta) versions, you can

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -109,6 +109,9 @@ if [ ! "$(stat -c '%U' /var/log/odoo)" = "odoo" ]; then
 fi
 
 BASE_CMD=$(basename $1)
+CMD_ARRAY=($*)
+ARGS=(${CMD_ARRAY[@]:1})
+
 if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] ; then
 
   BEFORE_MIGRATE_ENTRYPOINT_DIR=/before-migrate-entrypoint.d
@@ -116,8 +119,13 @@ if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] ; then
     run-parts --verbose "$BEFORE_MIGRATE_ENTRYPOINT_DIR"
   fi
 
-  if [ -z "$MIGRATE" -o "$MIGRATE" = True ]; then
-    gosu odoo migrate
+  # Bypass migrate when `odoo shell` or `odoo --help` are used
+  if [[ ! " ${ARGS[@]} " =~ " --help " ]] && [[ ! " ${ARGS[@]:0:1} " =~ " shell " ]]; then
+
+      if [ -z "$MIGRATE" -o "$MIGRATE" = True ]; then
+        gosu odoo migrate
+      fi
+
   fi
 
   START_ENTRYPOINT_DIR=/start-entrypoint.d


### PR DESCRIPTION
This might already have happened to you. You just want to launch a shell to check something in a database or launch the `--help` to check odoo parameters. Before this PR you would likely have to add explicitly a `-e MIGRATE=False`


The 2 following commands do not trigger entrypoints anymore
and are be executed straight forward.

docker-compose run --rm odoo odoo shell [...]
docker-compose run --rm odoo odoo [...] --help [...]