### PR TITLE
Fix pytest to 4.6

### DIFF
--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -63,7 +63,7 @@ anthem==0.13.0
 # those libs and their dependencies are unpinned
 # to always test with the last version of it
 flake8
-pytest
+pytest==4.6
 pluggy
 pytest-odoo
 coverage

--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -50,7 +50,7 @@ ERPpeek==1.7.1
 # those libs and their dependencies are unpinned
 # to always test with the last version of it
 flake8
-pytest
+pytest==4.6
 pytest-odoo
 coverage
 pytest-cov

--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -50,7 +50,7 @@ ERPpeek==1.7.1
 # those libs and their dependencies are unpinned
 # to always test with the last version of it
 flake8
-pytest
+pytest==4.6
 pytest-odoo
 coverage
 pytest-cov

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -57,7 +57,7 @@ anthem==0.13.0
 # those libs and their dependencies are unpinned
 # to always test with the last version of it
 flake8
-pytest
+pytest==4.6
 pytest-odoo
 coverage
 pytest-cov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,8 @@ Unreleased
 
 **Bugfixes**
 
+* [<= 10.0] Fix pytest version to 4.6, last supported version in Python 2.7
+
 **Libraries**
 
 **Build**


### PR DESCRIPTION
This is the last supported version for Python 2.7

This applis for Odoo <= 10.0

Fixes #141