### PR TITLE
Disable the cache for pip

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -38,8 +38,8 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
-        && pip install -r /odoo/base_requirements.txt \
+        && pip install --no-cache-dir -U pip "setuptools<45" \
+        && pip install --no-cache-dir -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 
 # grab gosu for easy step-down from root and dockerize to generate template and

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -37,8 +37,8 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_4.sh \
         && /install/dev_package.sh \
-        && python3 -m pip install --force-reinstall pip setuptools \
-        && pip3 install -r /odoo/base_requirements.txt --ignore-installed \
+        && python3 -m pip install --no-cache-dir --force-reinstall pip setuptools \
+        && pip3 install --no-cache-dir -r /odoo/base_requirements.txt --ignore-installed \
         && /install/purge_dev_package_and_cache.sh \
         && /install/reportlab_init.sh
 

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -37,8 +37,8 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_5.sh \
         && /install/dev_package.sh \
-        && python3 -m pip install --force-reinstall pip setuptools \
-        && pip3 install -r /odoo/base_requirements.txt --ignore-installed \
+        && python3 -m pip install --no-cache-dir --force-reinstall pip setuptools \
+        && pip3 install --no-cache-dir -r /odoo/base_requirements.txt --ignore-installed \
         && /install/purge_dev_package_and_cache.sh
 
 # grab gosu for easy step-down from root and dockerize to generate template and

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -37,8 +37,8 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_5_1.sh \
         && /install/dev_package.sh \
-        && python3 -m pip install --force-reinstall pip setuptools \
-        && pip install -r /odoo/base_requirements.txt --ignore-installed \
+        && python3 -m pip install --no-cache-dir --force-reinstall pip setuptools \
+        && pip install --no-cache-dir -r /odoo/base_requirements.txt --ignore-installed \
         && /install/purge_dev_package_and_cache.sh
 
 # grab gosu for easy step-down from root and dockerize to generate template and

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -39,8 +39,8 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
-        && pip install -r /odoo/base_requirements.txt \
+        && pip install --no-cache-dir -U pip "setuptools<45" \
+        && pip install --no-cache-dir -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 
 # grab gosu for easy step-down from root and dockerize to generate template and

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -39,8 +39,8 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
-        && pip install -r /odoo/base_requirements.txt \
+        && pip install --no-cache-dir -U pip "setuptools<45" \
+        && pip install --no-cache-dir -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 
 # grab gosu for easy step-down from root and dockerize to generate template and

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -38,8 +38,8 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
-        && pip install -r /odoo/base_requirements.txt \
+        && pip install --no-cache-dir -U pip "setuptools<45" \
+        && pip install --no-cache-dir -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 
 # grab gosu for easy step-down from root and dockerize to generate template and

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ Unreleased
 **Features and Improvements**
 
 * disable pip version checks (required network access, can timeout)
+* disable cache for pip instead of filling and erasing
 * Bypass migration when using:
 
     docker-compose run --rm odoo odoo shell [...]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -91,7 +91,7 @@ if [ -z "$(pip list --format=columns | grep "/odoo/src")" ]; then
   # the install everytime because it would slow the start of the containers
   echo '/odoo/src/odoo.egg-info is missing, probably because the directory is a volume.'
   echo 'Running pip install -e /odoo/src to restore odoo.egg-info'
-  pip install -e /odoo/src
+  pip install --no-cache-dir -e /odoo/src
   # As we write in a volume, ensure it has the same user.
   # So when the src is a host volume and we set the LOCAL_USER_ID to be the
   # host user, the files are owned by the host user
@@ -103,7 +103,7 @@ fi
 if [ -z "$(pip list --format=columns | grep "/odoo" | grep -v "/odoo/src")" ]; then
   echo '/src/*.egg-info is missing, probably because the directory is a volume.'
   echo 'Running pip install -e /odoo to restore *.egg-info'
-  pip install -e /odoo
+  pip install --no-cache-dir -e /odoo
   chown -R odoo: /odoo/*.egg-info
 fi
 

--- a/common/Dockerfile-batteries
+++ b/common/Dockerfile-batteries
@@ -7,7 +7,7 @@ COPY ./.coveragerc ./
 # Install extra requirement
 RUN set -x; \
         /install/dev_package.sh \
-        && pip install -r extra_requirements.txt \
+        && pip install --no-cache-dir -r extra_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 
 WORKDIR "/"

--- a/common/Dockerfile-onbuild
+++ b/common/Dockerfile-onbuild
@@ -13,4 +13,4 @@ ONBUILD COPY ./setup.py /odoo/
 ONBUILD COPY ./VERSION /odoo/
 ONBUILD COPY ./migration.yml /odoo/
 # need to be called at the end, because it installs . and src
-ONBUILD RUN cd /odoo && pip install -r src_requirements.txt
+ONBUILD RUN cd /odoo && pip install --no-cache-dir -r src_requirements.txt

--- a/example/odoo/Dockerfile
+++ b/example/odoo/Dockerfile
@@ -17,8 +17,8 @@ COPY ./VERSION /odoo/
 COPY ./migration.yml /odoo/
 
 RUN replace_dependencies.sh
-RUN pip install -e /odoo
-RUN pip install -e /odoo/src
+RUN pip install --no-cache-dir -e /odoo
+RUN pip install --no-cache-dir -e /odoo/src
 
 # Project's specifics packages
 RUN set -x; \
@@ -29,6 +29,6 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /odoo/
-RUN cd /odoo && pip install -r requirements.txt
+RUN cd /odoo && pip install --no-cache-dir -r requirements.txt
 
 ENV ADDONS_PATH=/odoo/local-src,/odoo/src/addons

--- a/example/odoo/Dockerfile-onbuild
+++ b/example/odoo/Dockerfile-onbuild
@@ -10,6 +10,6 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /odoo/
-RUN cd /odoo && pip install -r requirements.txt
+RUN cd /odoo && pip install --no-cache-dir -r requirements.txt
 
 ENV ADDONS_PATH=/odoo/local-src,/odoo/src/addons


### PR DESCRIPTION
This doesn't provide any significant change in size. It delegates the responsibility of not storing his own cache to pip instead of having to sweep everything after.

IMO it makes more sense than a post cleaning.