### PR TITLE
Fix wkhtmltopdf version for Odoo version <= 10

### DIFF
--- a/install/wkhtml_12_1_2.sh
+++ b/install/wkhtml_12_1_2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb
-echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c -
-dpkg --force-depends -i wkhtmltox.deb
-rm wkhtmltox.deb
+# curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb
+echo 'bd86f4cc9bf7a515ba038ddb8b60eaffc1c4e2b9 /install/wkhtmltox.deb' | sha1sum -c -
+dpkg --force-depends -i /install/wkhtmltox.deb
+rm /install/wkhtmltox.deb


### PR DESCRIPTION
This PR is intended to circumvent the deletion of the package for wkhtmltopdf version 0.12.1.2 on Odoo side as it was considered deprecated.
I manually recompiled the package, but the solution to integrate it in the image proposed here is far from being optimal, so I gladly update it if you have any better idea