### PR TITLE
[14.0] Downgrade urllib3 to match requests requirement

### DIFF
--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -57,7 +57,7 @@ odoo-autodiscover==2.0.0
 pyinotify==0.9.6
 python-stdnum==1.13
 simplejson==3.17.0
-urllib3==1.25.9
+urllib3==1.24.3
 
 # Migration tools
 marabunta==0.10.5

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,7 @@ Unreleased
 **Libraries**
 
 * Update Marabunta to 0.10.5
+* [14.0] Downgrade `urllib3` to a compatible version with Odoo supported `requests` version.
 
 **Build**
 


### PR DESCRIPTION
Odoo's version is stuck to requsets == 2.21.0

This forces us to downgrade to a compatible version of `urllib3`