### PR TITLE
odoo-autodiscover is not necessary for Odoo 11.0 and later

### DIFF
--- a/11.0/base_requirements.txt
+++ b/11.0/base_requirements.txt
@@ -49,7 +49,6 @@ chardet==3.0.4
 gdata==2.0.18
 html5lib==1.0.1
 odfpy==1.3.5
-odoo-autodiscover==2.0.0
 pyinotify==0.9.6
 python-stdnum==1.9
 simplejson==3.11.1

--- a/12.0-buster/base_requirements.txt
+++ b/12.0-buster/base_requirements.txt
@@ -45,7 +45,6 @@ chardet==3.0.4
 gdata==2.0.18
 html5lib==1.0.1
 odfpy==1.3.5
-odoo-autodiscover==2.0.0
 pyinotify==0.9.6
 python-stdnum==1.9
 simplejson==3.11.1

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -45,7 +45,6 @@ chardet==3.0.4
 gdata==2.0.18
 html5lib==1.0.1
 odfpy==1.3.5
-odoo-autodiscover==2.0.0
 pyinotify==0.9.6
 python-stdnum==1.9
 simplejson==3.11.1

--- a/13.0/base_requirements.txt
+++ b/13.0/base_requirements.txt
@@ -45,7 +45,6 @@ xlrd==1.1.0
 gdata==2.0.18
 html5lib==1.0.1
 odfpy==1.4.1
-odoo-autodiscover==2.0.0
 pyinotify==0.9.6
 python-stdnum==1.13
 simplejson==3.17.0

--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -53,7 +53,6 @@ xlrd==1.2.0; python_version >= '3.8'
 gdata==2.0.18
 html5lib==1.0.1
 odfpy==1.4.1
-odoo-autodiscover==2.0.0
 pyinotify==0.9.6
 python-stdnum==1.13
 simplejson==3.17.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,6 +39,7 @@ Unreleased
 
 * Update Marabunta to 0.10.5
 * [14.0] Downgrade `urllib3` to a compatible version with Odoo supported `requests` version.
+* [>= 12.0] Remove `odoo-autodiscover` as it's not necessary since Odoo 12.0.
 
 **Build**
 


### PR DESCRIPTION
According to https://github.com/acsone/odoo-autodiscover#odoo-autodiscover

Thus we should be able to safely remove it and restore the CI