### PR TITLE
[<=10.0] Fix legacy build for Py2 based versions

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
+        && pip install -U "pip<21.0" "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -90,3 +90,4 @@ pycodestyle==2.3.1
 pyflakes==1.6.0
 unicodecsv==0.14.1
 wrapt==1.10.11
+zipp==1.2.0

--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -67,8 +67,8 @@ pytest==4.6
 pluggy
 pytest-odoo
 coverage
+watchdog==0.10.6
 pytest-cov
-watchdog
 
 # Library dependency
 argh==0.26.2

--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -56,6 +56,7 @@ xlrd==1.0.0
 pydot==1.2.3
 
 # Migration tools
+ruamel.yaml==0.16.13
 marabunta==0.10.5
 anthem==0.13.0
 

--- a/10.0/base_requirements.txt
+++ b/10.0/base_requirements.txt
@@ -79,6 +79,7 @@ beautifulsoup4==4.6.0
 configparser==3.5.0
 enum34==1.1.6
 funcsigs==1.0.2
+importlib-metadata==2.1.1
 mccabe==0.6.1
 more-itertools==4.2.0
 pathtools==0.1.2

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -40,7 +40,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
+        && pip install -U "pip<21.0" "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -65,6 +65,7 @@ beautifulsoup4==4.6.0
 configparser==3.5.0
 enum34==1.1.6
 funcsigs==1.0.2
+importlib-metadata==2.1.1
 mccabe==0.6.1
 more-itertools==4.2.0
 pathtools==0.1.2

--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -53,8 +53,8 @@ flake8
 pytest==4.6
 pytest-odoo
 coverage
+watchdog==0.10.6
 pytest-cov
-watchdog
 
 # Library dependency
 argh==0.26.2

--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -43,6 +43,7 @@ wsgiref==0.1.2
 xlwt==0.7.5
 
 # Migration tools
+ruamel.yaml==0.16.13
 marabunta==0.10.5
 ERPpeek==1.7.1
 

--- a/7.0/base_requirements.txt
+++ b/7.0/base_requirements.txt
@@ -76,3 +76,4 @@ pycodestyle==2.3.1
 pyflakes==1.6.0
 unicodecsv==0.14.1
 wrapt==1.10.11
+zipp==1.2.0

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -40,7 +40,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
+        && pip install -U "pip<21.0" "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -65,6 +65,7 @@ beautifulsoup4==4.6.0
 configparser==3.5.0
 enum34==1.1.6
 funcsigs==1.0.2
+importlib-metadata==2.1.1
 mccabe==0.6.1
 more-itertools==4.2.0
 pathtools==0.1.2

--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -53,8 +53,8 @@ flake8
 pytest==4.6
 pytest-odoo
 coverage
+watchdog==0.10.6
 pytest-cov
-watchdog
 
 # Library dependency
 argh==0.26.2

--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -43,6 +43,7 @@ wsgiref==0.1.2
 xlwt==0.7.5
 
 # Migration tools
+ruamel.yaml==0.16.13
 marabunta==0.10.5
 ERPpeek==1.7.1
 

--- a/8.0/base_requirements.txt
+++ b/8.0/base_requirements.txt
@@ -76,3 +76,4 @@ pycodestyle==2.3.1
 pyflakes==1.6.0
 unicodecsv==0.14.1
 wrapt==1.10.11
+zipp==1.2.0

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x; \
         && /install/postgres.sh \
         && /install/wkhtml_12_1_2.sh \
         && /install/dev_package.sh \
-        && pip install -U pip "setuptools<45" \
+        && pip install -U "pip<21.0" "setuptools<45" \
         && pip install -r /odoo/base_requirements.txt \
         && /install/purge_dev_package_and_cache.sh
 

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -83,3 +83,4 @@ pycodestyle==2.3.1
 pyflakes==1.6.0
 unicodecsv==0.14.1
 wrapt==1.10.11
+zipp==1.2.0

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -60,8 +60,8 @@ flake8
 pytest==4.6
 pytest-odoo
 coverage
+watchdog==0.10.6
 pytest-cov
-watchdog
 
 # Library dependency
 argh==0.26.2

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -50,6 +50,7 @@ pydot==1.2.3
 suds-jurko==0.6
 
 # Migration tools
+ruamel.yaml==0.16.13
 marabunta==0.10.5
 anthem==0.13.0
 

--- a/9.0/base_requirements.txt
+++ b/9.0/base_requirements.txt
@@ -72,6 +72,7 @@ beautifulsoup4==4.6.0
 configparser==3.5.0
 enum34==1.1.6
 funcsigs==1.0.2
+importlib-metadata==2.1.1
 mccabe==0.6.1
 more-itertools==4.2.0
 pathtools==0.1.2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,6 +41,7 @@ Unreleased
 * [14.0] Downgrade `urllib3` to a compatible version with Odoo supported `requests` version.
 * [>= 12.0] Remove `odoo-autodiscover` as it's not necessary since Odoo 12.0.
 * [12.0] Pin `watchdog` to Py3.5 compatible versions
+* [<= 10.0] Pin `watchdog` to last Py2 compatible version
 
 **Build**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,6 +41,7 @@ Unreleased
 * [14.0] Downgrade `urllib3` to a compatible version with Odoo supported `requests` version.
 * [>= 12.0] Remove `odoo-autodiscover` as it's not necessary since Odoo 12.0.
 * [12.0] Pin `watchdog` to Py3.5 compatible versions
+* [<= 10.0] Pin `pip` to last Py2 compatible version
 * [<= 10.0] Pin `watchdog` to last Py2 compatible version
 * [<= 10.0] Pin `ruamel.yaml` to last Py2 compatible version
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,6 +42,7 @@ Unreleased
 * [>= 12.0] Remove `odoo-autodiscover` as it's not necessary since Odoo 12.0.
 * [12.0] Pin `watchdog` to Py3.5 compatible versions
 * [<= 10.0] Pin `watchdog` to last Py2 compatible version
+* [<= 10.0] Pin `ruamel.yaml` to last Py2 compatible version
 
 **Build**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,6 +45,7 @@ Unreleased
 * [<= 10.0] Pin `watchdog` to last Py2 compatible version
 * [<= 10.0] Pin `ruamel.yaml` to last Py2 compatible version
 * [<= 10.0] Pin `importlib-metadata` to last Py2 compatible version
+* [<= 10.0] Pin `zipp` to last Py2 compatible version
 
 **Build**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,6 +44,7 @@ Unreleased
 * [<= 10.0] Pin `pip` to last Py2 compatible version
 * [<= 10.0] Pin `watchdog` to last Py2 compatible version
 * [<= 10.0] Pin `ruamel.yaml` to last Py2 compatible version
+* [<= 10.0] Pin `importlib-metadata` to last Py2 compatible version
 
 **Build**
 


### PR DESCRIPTION
With the depreciation of Python 2 some libraries have dropped compatibility.

This restores the build for legacy version (and hopefully make the CI greener)