### PR TITLE
Copy 14MB of deb only on older versions

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ sed -i "1i FROM ${IMAGE_LATEST}" ${TMP}/Dockerfile-onbuild
 sed -i "1i FROM ${IMAGE_LATEST}" ${TMP}/Dockerfile-batteries
 sed -i "1i FROM ${IMAGE_LATEST}-batteries" ${TMP}/Dockerfile-batteries-onbuild
 cp -r install/ ${TMP}
+cp -r install-extra/ ${TMP}
 cp -r start-entrypoint.d/ ${TMP}
 cp -r before-migrate-entrypoint.d/ ${TMP}
 

--- a/install/wkhtml_12_1_2.sh
+++ b/install/wkhtml_12_1_2.sh
@@ -2,6 +2,6 @@
 set -eo pipefail
 
 # curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb
-echo 'bd86f4cc9bf7a515ba038ddb8b60eaffc1c4e2b9 /install/wkhtmltox.deb' | sha1sum -c -
-dpkg --force-depends -i /install/wkhtmltox.deb
-rm /install/wkhtmltox.deb
+echo 'bd86f4cc9bf7a515ba038ddb8b60eaffc1c4e2b9 /install/wkhtmltox_12_1_2.deb' | sha1sum -c -
+dpkg --force-depends -i /install/wkhtmltox_12_1_2.deb
+rm /install/wkhtmltox_12_1_2.deb


### PR DESCRIPTION
Following #147 

This avoid putting an extra 14MB in images > 10.0