### PR TITLE
[11.0,12.0] Pin watchdog before Py3.5 compat break

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/11.0/base_requirements.txt
+++ b/11.0/base_requirements.txt
@@ -66,8 +66,9 @@ pytest
 pluggy
 coverage
 pytest-odoo
+# watchdog 1.0.0 drops compatibility with Python 3.5
+watchdog<1.0.0
 pytest-cov
-watchdog
 
 # Library dependency
 argh==0.26.2

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -62,8 +62,9 @@ pytest
 pluggy
 coverage
 pytest-odoo
+# watchdog 1.0.0 drops compatibility with Python 3.5
+watchdog<1.0.0
 pytest-cov
-watchdog
 
 # Library dependency
 argh==0.26.2

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /odoo /var/log/odoo
 
 COPY ./base_requirements.txt /odoo
 COPY ./install /install
+COPY ./install-extra/wkhtmltox_12_1_2.deb /install
 
 # Set Locale it needs to be present when installing python packages.
 # Otherwise it can lead to issues. eg. when reading the setup.cfg

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,6 +40,7 @@ Unreleased
 * Update Marabunta to 0.10.5
 * [14.0] Downgrade `urllib3` to a compatible version with Odoo supported `requests` version.
 * [>= 12.0] Remove `odoo-autodiscover` as it's not necessary since Odoo 12.0.
+* [12.0] Pin `watchdog` to Py3.5 compatible versions
 
 **Build**
 

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ sed -i "1i FROM ${IMAGE_LATEST}" ${TMP}/Dockerfile-onbuild
 sed -i "1i FROM ${IMAGE_LATEST}" ${TMP}/Dockerfile-batteries
 sed -i "1i FROM ${IMAGE_LATEST}-batteries" ${TMP}/Dockerfile-batteries-onbuild
 cp -r install/ ${TMP}
+cp -r install-extra/ ${TMP}
 cp -r start-entrypoint.d/ ${TMP}
 cp -r before-migrate-entrypoint.d/ ${TMP}
 

--- a/install/wkhtml_12_1_2.sh
+++ b/install/wkhtml_12_1_2.sh
@@ -2,6 +2,6 @@
 set -eo pipefail
 
 # curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb
-echo 'bd86f4cc9bf7a515ba038ddb8b60eaffc1c4e2b9 /install/wkhtmltox.deb' | sha1sum -c -
-dpkg --force-depends -i /install/wkhtmltox.deb
-rm /install/wkhtmltox.deb
+echo 'bd86f4cc9bf7a515ba038ddb8b60eaffc1c4e2b9 /install/wkhtmltox_12_1_2.deb' | sha1sum -c -
+dpkg --force-depends -i /install/wkhtmltox_12_1_2.deb
+rm /install/wkhtmltox_12_1_2.deb


### PR DESCRIPTION
All version after watchdog 1.0.0 dropped support for Py3.5