### PR TITLE
[IMP] facilitate the use of .pgpass

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -17,6 +17,8 @@ export PGDATABASE=${DB_NAME}
 # As docker-compose exec do not launch the entrypoint
 # init PG variable into .bashrc so it will be initialized
 # when doing docker-compose exec odoo gosu odoo bash
+touch /home/odoo/.bashrc
+chown odoo:odoo /home/odoo/.bashrc
 echo "
 export PGHOST=${DB_HOST}
 export PGPORT=${DB_PORT}

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -12,7 +12,6 @@ id -u odoo &> /dev/null || useradd --shell /bin/bash -u $USER_ID -o -c "" -m odo
 export PGHOST=${DB_HOST}
 export PGPORT=${DB_PORT}
 export PGUSER=${DB_USER}
-export PGPASSWORD=${DB_PASSWORD}
 export PGDATABASE=${DB_NAME}
 
 # As docker-compose exec do not launch the entrypoint
@@ -22,9 +21,16 @@ echo "
 export PGHOST=${DB_HOST}
 export PGPORT=${DB_PORT}
 export PGUSER=${DB_USER}
-export PGPASSWORD=${DB_PASSWORD}
 export PGDATABASE=${DB_NAME}
 " >> /home/odoo/.bashrc
+
+# Only set PGPASSWORD if there is no .pgpass file
+if [ ! -f /home/odoo/.pgpass ]; then
+    export PGPASSWORD=${DB_PASSWORD}
+    echo "
+    export PGPASSWORD=${DB_PASSWORD}
+    " >> /home/odoo/.bashrc
+fi
 
 # Accepted values for DEMO: True / False
 # Odoo use a reverse boolean for the demo, which is not handy,


### PR DESCRIPTION
by default $PGPASSWORD will be used instead of .pgpass value.

With this commit, if a .pgpass is mounted there will be no $PGPASSWORD and then .pgpass will function as intended