### PR TITLE
Fix qrcode generation in 14 (reportlab update)

### DIFF
--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -47,7 +47,7 @@ python-dateutil==2.7.3
 pytz==2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.13; python_version < '3.8'
+reportlab==3.5.54; python_version < '3.8' # official 3.5.13
 # reportlab==3.5.55; python_version >= '3.8'
 requests==2.25.1  # official 2.21.0
 zeep==3.2.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -59,6 +59,7 @@ Unreleased
 * [13.0-15.0] Bump Pillow, urllib3 and requests to fix potential security issues
 * [14.0,15.0] Upgrade to same Psycopg2 and Jinja2 versions
 * [15.0] Bump lxml to version 4.6.3
+* [14.0] Bump reportlab version to fix printing qr code
 
 **Build**
 


### PR DESCRIPTION
When printing an invoice with a qrcode.
The call to reportlab.graphics.barcode.createBarcodeDrawing
would raise the following error:

    AttributeError("'Image' object has no attribute 'fromstring'")