### PR TITLE
bugfix(15.0 docker): restore wkhtmltopdf on python3

### DIFF
--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -36,6 +36,7 @@ RUN set -x; \
         && /install/setup-pip.sh \
         && /install/postgres.sh \
         && /install/kwkhtml_client.sh \
+        && /install/kwkhtml_client_force_python3.sh \
         && /install/dev_package.sh \
         && python3 -m pip install --force-reinstall pip "setuptools<58" \
         && pip install -r /odoo/base_requirements.txt --ignore-installed \


### PR DESCRIPTION
This restores the compatibility mode of the wkhtmltopdf client with python3-based environments. Without it, it is not possible to print on odoo15 instances. 