### PR TITLE
feat: bump reportlab for barcode issue

### DIFF
--- a/12.0-buster/base_requirements.txt
+++ b/12.0-buster/base_requirements.txt
@@ -40,7 +40,8 @@ python-dateutil==2.5.3
 pytz==2016.7
 pyusb==1.0.0
 qrcode==5.3
-reportlab==3.3.0
+feedparser==6.0.8
+reportlab==3.5.55; python_version >= '3.8'
 requests==2.20.0
 suds-jurko==0.6
 vatnumber==1.2

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -39,7 +39,8 @@ python-dateutil==2.5.3
 pytz==2016.7
 pyusb==1.0.0
 qrcode==5.3
-reportlab==3.3.0
+feedparser==6.0.8
+reportlab==3.5.55; python_version >= '3.8'
 requests==2.20.0
 suds-jurko==0.6
 vatnumber==1.2

--- a/13.0/base_requirements.txt
+++ b/13.0/base_requirements.txt
@@ -40,7 +40,8 @@ python-dateutil==2.7.3
 pytz==2020.1 # official 2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.42 # official 3.5.13
+feedparser==6.0.8
+reportlab==3.5.55; python_version >= '3.8'
 requests==2.25.1  # official 2.21.0
 zeep==3.2.0
 vatnumber==1.2

--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -47,8 +47,8 @@ python-dateutil==2.7.3
 pytz==2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.54; python_version < '3.8' # official 3.5.13
-# reportlab==3.5.55; python_version >= '3.8'
+feedparser==6.0.8
+reportlab==3.5.55; python_version >= '3.8'
 requests==2.25.1  # official 2.21.0
 zeep==3.2.0
 python-stdnum==1.13  # official 1.8

--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -43,7 +43,7 @@ python-dateutil==2.7.3
 pytz==2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.13; python_version < '3.8'
+feedparser==6.0.8
 reportlab==3.5.55; python_version >= '3.8'
 requests==2.25.1  # official 2.21.0
 zeep==3.2.0


### PR DESCRIPTION
* Purpose
Due to upgrade on report in odoo, we need to bump version to be able to print report again