### PR TITLE
feat(postgresql): set application name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,7 @@ Unreleased
 
 **Features and Improvements**
 
+* Set PostgreSQL application name using hostname
 
 **Bugfixes**
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -13,6 +13,7 @@ export PGHOST=${DB_HOST}
 export PGPORT=${DB_PORT}
 export PGUSER=${DB_USER}
 export PGDATABASE=${DB_NAME}
+export PGAPPNAME=${HOSTNAME}
 
 # As docker-compose exec do not launch the entrypoint
 # init PG variable into .bashrc so it will be initialized
@@ -24,6 +25,7 @@ export PGHOST=${DB_HOST}
 export PGPORT=${DB_PORT}
 export PGUSER=${DB_USER}
 export PGDATABASE=${DB_NAME}
+export PGAPPNAME=${HOSTNAME}
 " >> /home/odoo/.bashrc
 
 # Only set PGPASSWORD if there is no .pgpass file


### PR DESCRIPTION
Setting PostgreSQL application name using the hostname allows to easily distinguish the pods connected to PostgreSQL on Grafana dashboards.