### PR TITLE
Support arm64 platform

### DIFF
--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -22,6 +22,7 @@ ENV BUILD_PACKAGE \
     libxml2-dev \
     libxslt1-dev \
     libsasl2-dev \
+    libffi-dev \
     libldap2-dev \
     libssl-dev \
     libjpeg-dev \

--- a/install/dockerize.sh
+++ b/install/dockerize.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -eo pipefail
 
-curl -o dockerize-linux-amd64-v0.6.0.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz -SL
-echo 'a13ff2aa6937f45ccde1f29b1574744930f5c9a5 dockerize-linux-amd64-v0.6.0.tar.gz' | sha1sum -c -
-tar xvfz dockerize-linux-amd64-v0.6.0.tar.gz -C /usr/local/bin && rm dockerize-linux-amd64-v0.6.0.tar.gz
+arch=`uname -m`
+if [[ arch -eq 'aarch64' ]]; then
+  arch="arm64"
+  hash="541ee4713933e087d766e2954b37cc652dff73b569d26b0c589277dcf8b16a9a"
+else
+  # assume x86_64
+  hash="6981643dfb8e0b731f4b48b35d1fdd742b374ec66d1471a9ed7ed91781f2aca7"
+fi
+curl -o dockerize-linux-${arch} https://github.com/powerman/dockerize/releases/download/v0.16.0/dockerize-linux-${arch} -SL
+echo "${hash}  dockerize-linux-${arch}" | sha256sum -c -
+install dockerize-linux-${arch} /usr/local/bin/dockerize && rm dockerize-linux-${arch}


### PR DESCRIPTION
switched on a fork of dockerize (more active and publish arm builds)
added a missing dependency when building on arm.