### PR TITLE
Fix 7a18a129, issue GH #197 and #179

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -133,7 +133,7 @@ BASE_CMD=$(basename $1)
 CMD_ARRAY=($*)
 ARGS=(${CMD_ARRAY[@]:1})
 
-if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] || ([ "$BASE_CMD" = "gosu" ] && [ "${ARGS[@]}" = "odoo migrate" ] ); then
+if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] || ([ "$BASE_CMD" = "gosu" ] && [ "${ARGS[*]}" = "odoo migrate" ] ); then
 
   BEFORE_MIGRATE_ENTRYPOINT_DIR=/before-migrate-entrypoint.d
   if [ -d "$BEFORE_MIGRATE_ENTRYPOINT_DIR" ]; then


### PR DESCRIPTION
Found this error in log file on marabunta upgrade:
```
/odoo-bin/docker-entrypoint.sh: line 134: [: too many arguments
```

This one-byte-fix should do the job.