### PR TITLE
fix(v15): Replace deprecated git url in requirements

### DIFF
--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -70,7 +70,7 @@ urllib3==1.26.7
 
 # Migration tools
 marabunta==0.10.5
--e git://github.com/camptocamp/anthem@master#egg=anthem
+-e git+https://github.com/camptocamp/anthem@master#egg=anthem
 
 # test / lint
 # those libs and their dependencies are unpinned


### PR DESCRIPTION
According to https://github.blog/2021-09-01-improving-git-protocol-security-github/