### PR TITLE
Fix 12.0: restore feedparser

### DIFF
--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -40,6 +40,7 @@ python-dateutil==2.5.3
 pytz==2016.7
 pyusb==1.0.0
 qrcode==5.3
+feedparser==6.0.8
 reportlab==3.5.52
 requests==2.20.0
 suds-jurko==0.6


### PR DESCRIPTION
Fix 12.0: restore feedparser It was removed in https://github.com/camptocamp/docker-odoo-project/pull/184 .
But starting the project from scratch is making an odoo 12.0 failing.

Context: I have done a `doco build` after getting the last version of a project updated with the dockerimage 12.0.4.4.3 and starting the project I had the follwing error:

```
Traceback (most recent call last):
  File "/usr/local/bin/odoo", line 4, in <module>
    __import__('pkg_resources').require('odoo==12.0')
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 3238, in <module>
    @_call_aside
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 3222, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 3251, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 567, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 884, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 770, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'feedparser' distribution was not found and is required by odoo
```

EDIT
was removed in -> https://github.com/odoo/odoo/commit/271b9468c999454527f106b4db177665afeef8ca
but not all 12.0 contains it (it's not the case for Schweizmobil
