### PR TITLE
[16.0] Fix: xlrd version

### DIFF
--- a/16.0/base_requirements.txt
+++ b/16.0/base_requirements.txt
@@ -37,7 +37,8 @@ vobject==0.9.6.1
 Werkzeug==0.16.1
 XlsxWriter==3.0.3
 xlwt==1.3.0
-xlrd==2.0.1
+xlrd==1.1.0; python_version < '3.8'
+xlrd==1.2.0; python_version >= '3.8'
 pyOpenSSL==22.1.0
 
 setuptools<58

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,8 @@ Unreleased
 
 **Bugfixes**
 
+* [16.0] Fix: xlrd version
+
 **Libraries**
 
 **Build**


### PR DESCRIPTION
Context: the xlrd version 2.0.1 fails in odoo version 16, resulting in the error seen in the photo bellow. Resetting it back to the way odoo used it or using **xlrd >= 1.0.0** works, I tested in both cases.



![adiant_xlrd_version_fail](https://user-images.githubusercontent.com/29477079/220301335-245b1a3c-3310-4275-a7a1-65f395074ba2.png)
