### PR TITLE
[12.0-15.0] Pin reportlab for all Python versions

### DIFF
--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -39,7 +39,7 @@ python-dateutil==2.5.3
 pytz==2016.7
 pyusb==1.0.0
 qrcode==5.3
-reportlab==3.5.55; python_version >= '3.8'
+reportlab==3.6.9
 requests==2.20.0
 suds-jurko==0.6
 vatnumber==1.2

--- a/13.0/base_requirements.txt
+++ b/13.0/base_requirements.txt
@@ -40,7 +40,7 @@ python-dateutil==2.7.3
 pytz==2020.1 # official 2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.55; python_version >= '3.8'
+reportlab==3.6.9
 requests==2.25.1  # official 2.21.0
 zeep==3.2.0
 vatnumber==1.2

--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -47,7 +47,7 @@ python-dateutil==2.7.3
 pytz==2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.55; python_version >= '3.8'
+reportlab==3.6.9
 requests==2.25.1  # official 2.21.0
 zeep==3.2.0
 python-stdnum==1.13  # official 1.8

--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -43,7 +43,7 @@ python-dateutil==2.7.3
 pytz==2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.55; python_version >= '3.8'
+reportlab==3.6.9
 requests==2.25.1  # official 2.21.0
 zeep==3.2.0
 python-stdnum==1.13  # official 1.8

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,6 +31,8 @@ Unreleased
 
 **Build**
 
+* [12.0-15.0] Pin ReportLab to 3.6.9
+
 **Documentation**
 
 4.5.4 (2023-04-27)


### PR DESCRIPTION
By mistake, Reportlab was only pinned with Python >= 3.8

Consequence seen when build tried to install ReportLab 4.0.0 and failed building pycairo binary wheels.
