### PR TITLE
Give a dedicated cachedb dir for volume mount

### DIFF
--- a/bin/runmigration
+++ b/bin/runmigration
@@ -35,7 +35,7 @@
 set -e
 
 wait_postgres.sh
-CACHE_DIR=/tmp
+CACHE_DIR=${CACHE_DIR:=/tmp/cachedb}
 
 echo $CACHE_DIR
 

--- a/bin/runtests
+++ b/bin/runtests
@@ -30,7 +30,7 @@ set -e
 
 wait_postgres.sh
 LOCAL_SRC_DIR=/odoo/local-src
-CACHE_DIR=/tmp
+CACHE_DIR=${CACHE_DIR:=/tmp/cachedb}
 
 if [ -z $1 ]; then
     LOCAL_ADDONS=$(find ${LOCAL_SRC_DIR}/* -maxdepth 0 -type d -and -not -name server_environment_files -printf "%f\n" |


### PR DESCRIPTION
In order to extract the DB dump from the image we want this folder to be standalone especially in the CI