### PR TITLE
Refactor DB cache management in runtests and runmigration

### DIFF
--- a/bin/db.sh
+++ b/bin/db.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+db_restore() {
+    DUMP=$1
+    DB_NAME=$2
+    if [ -f "$DUMP" ]; then
+        echo "🐘 🐘 Database dump $DUMP found 🐘 🐘"
+        echo "Restore Database dump from $DUMP 📦⮕ 🐘"
+        psql -q -o /dev/null -d $DB_NAME -f "$DUMP"
+        psql -d $DB_NAME -P pager=off -c "SELECT name as installed_module FROM ir_module_module WHERE state = 'installed' ORDER BY name"
+        return 1
+    else
+        echo "No dump found matching"
+        return 0
+    fi
+}
+
+db_save() {
+    DB_NAME=$1
+    DUMP=$2
+    if [ ! -z "$DUMP" ]; then
+        echo "Dumping $DB_NAME into $DUMP 🐘⮕ 📦"
+        mkdir -p $(dirname $DUMP)
+        pg_dump -Fp -d $DB_NAME -O -f "$DUMP"
+        ls $DUMP
+    fi
+}

--- a/bin/runmigration
+++ b/bin/runmigration
@@ -11,8 +11,6 @@
 #
 # And finally make a database dump if none exists for current VERSION.
 #
-# TODO: store cache on S3 to store one DB per version
-#
 # Environment variables:
 #
 # CREATE_DB_CACHE:
@@ -34,14 +32,17 @@
 #   steps on top of it.
 set -e
 
+source ./db.sh
 wait_postgres.sh
-CACHE_DIR=/tmp/cachedb
 
+CREATE_DB_CACHE=${CREATE_DB_CACHE:=false}
+LOAD_DB_CACHE=${LOAD_DB_CACHE:=true}
+
+CACHE_DIR=${CACHE_DIR:=/tmp/cachedb}
 echo $CACHE_DIR
+DB_NAME=${DB_NAME:=odoo_mig}
 
 VERSION=$(cat /odoo/VERSION)
-
-CACHED_DUMP="$CACHE_DIR/odoo_sample_$VERSION.dmp"
 
 if [ "$LOAD_DB_CACHE" != "false" ]; then
 
@@ -52,31 +53,30 @@ if [ "$LOAD_DB_CACHE" != "false" ]; then
         if [ -d "$CACHE_DIR" ]; then
             # Filter dumps of higher releases
             export MAX_DUMP="$CACHE_DIR/odoo_sample_${MIG_LOAD_VERSION_CEIL}.dmp"
-            CACHED_DUMP=$(ls -v $CACHE_DIR/odoo_sample_*.dmp | awk '$0 < ENVIRON["MAX_DUMP"]' | tail -n1)
-        else
+            CACHED_DUMP=$(ls -v $CACHE_DIR/odoo_sample_*.dmp || true | awk '$0 < ENVIRON["MAX_DUMP"]' | tail -n1)
+        fi
+        if [ -n "$CACHED_DUMP" ]; then
             echo "No cached migration sample dump found"
         fi
     fi
 else
-    echo "Dump cache load disabled."
+    echo "DB cache load disabled."
 fi
 
-if [ "$LOAD_DB_CACHE" != "false" -a -f "$CACHED_DUMP" ]; then
-    echo "🐘 🐘 Database dump ${CACHED_DUMP} found 🐘 🐘"
-    echo "Restore Database dump from cache 📦⮕ 🐘"
-    createdb -O $DB_USER $DB_NAME
-    psql -q -o /dev/null -f "$CACHED_DUMP"
-    echo "Do migration on top of restored dump"
-else
-    echo "Do migration from scratch 🐢 🐢 🐢"
+if [ "$LOAD_DB_CACHE" != "false" ]; then
+    db_restore $CACHED_DUMP $DB_NAME_TEST
+    if [ $? = 1 ]; then
+        echo "Do migration on top of restored dump"
+    else
+        echo "Do migration from scratch 🐢 🐢 🐢"
+    fi
 fi
 
 migrate
 
+DUMP="$CACHE_DIR/odoo_sample_$VERSION.dmp"
 # Create a dump if none exist for the current VERSION
-if [ "$CREATE_DB_CACHE" == "true" -a ! -f "$CACHED_DUMP" ]; then
-    echo "Save DB to cache $CACHED_DUMP 🐘⮕ 📦"
+if [ "$CREATE_DB_CACHE" == "true" -a ! -f $DUMP ]; then
     mkdir -p "$CACHE_DIR"
-    pg_dump -Fp -O -f "$CACHED_DUMP"
-    ls -l $CACHED_DUMP
+    db_save $DB_NAME_TEST $DUMP
 fi

--- a/bin/runmigration
+++ b/bin/runmigration
@@ -35,7 +35,7 @@
 set -e
 
 wait_postgres.sh
-CACHE_DIR=/tmp
+CACHE_DIR=/tmp/cachedb
 
 echo $CACHE_DIR
 

--- a/bin/runtests
+++ b/bin/runtests
@@ -27,10 +27,8 @@
 set -e
 
 # TODO: if we are not in TRAVIS, make a template then run tests on a copy
-
+source db.sh
 wait_postgres.sh
-LOCAL_SRC_DIR=/odoo/local-src
-CACHE_DIR=/tmp/cachedb
 
 if [ -z $1 ]; then
     LOCAL_ADDONS=$(find ${LOCAL_SRC_DIR}/* -maxdepth 0 -type d -and -not -name server_environment_files -printf "%f\n" |
@@ -40,39 +38,46 @@ else
     LOCAL_ADDONS=$1
 fi
 
+CREATE_DB_CACHE=${CREATE_DB_CACHE:=false}
+LOAD_DB_CACHE=${LOAD_DB_CACHE:=true}
+
+LOCAL_SRC_DIR=${LOCAL_SRC_DIR:=/odoo/local-src}
+CACHE_DIR=${CACHE_DIR:=/tmp/cachedb}
+
 DEPS_ADDONS=$(list_dependencies.py "$LOCAL_ADDONS")
 
-DB_NAME_TEST=${DB_NAME}_test
+DB_NAME=${DB_NAME:=odoo_test}
 
 echo "Create database"
-createdb -O $DB_USER ${DB_NAME_TEST}
+createdb -O $DB_USER $DB_NAME
 
 if [[ ! -z "$SUBS_MD5" ]]; then
-    CACHED_DUMP="$CACHE_DIR/odoo_test_$SUBS_MD5.dmp"
+    DUMP="$CACHE_DIR/odoo_test_$SUBS_MD5.dmp"
 fi
 
 echo "Submodule addons MD5 is: $SUBS_MD5"
 
-if [ "$LOAD_DB_CACHE" != "false" -a -f "$CACHED_DUMP" ]; then
-    echo "🐘 🐘 Database dump ${CACHED_DUMP} found 🐘 🐘"
-    echo "Restore Database dump from cache matching MD5 📦⮕ 🐘"
-    psql -q -o /dev/null -d $DB_NAME_TEST -f "$CACHED_DUMP"
-    psql -d $DB_NAME_TEST -P pager=off -c "SELECT name as installed_module FROM ir_module_module WHERE state = 'installed' ORDER BY name"
-else
-    if [ "$LOAD_DB_CACHE" == "false" ]; then
-        echo "Dump cache load disabled."
+DUMP_LOADED=false
+if [ "$LOAD_DB_CACHE" != "false" ]; then
+    db_restore $DUMP $DB_NAME
+    DUMP_LOADED=$?
+    if [ $DUMP_LOADED = 1 ]; then
+        echo "Use restored dump with official/OCA modules"
     else
-        echo "No cached dump found matching MD5 🐢 🐢 🐢"
+        echo "Reinstall all addons from scratch 🐢 🐢 🐢"
     fi
+else
+    echo "DB cache load disabled."
+fi
+
+if [ "$DUMP_LOADED" = 0 ]; then
     echo "🔨🔨 Install official/OCA modules 🔨🔨"
-    odoo --stop-after-init --workers=0 --database $DB_NAME_TEST --log-level=warn --without-demo="" --db-filter=$DB_NAME_TEST -i ${DEPS_ADDONS}
-    if [ "$CREATE_DB_CACHE" == "true" -a ! -z "$CACHED_DUMP" ]; then
-        echo "Generate dump $CACHED_DUMP into cache 🐘⮕ 📦"
-        mkdir -p "$CACHE_DIR"
-        pg_dump -Fp -d $DB_NAME_TEST -O -f "$CACHED_DUMP"
+    odoo --stop-after-init --workers=0 --database $DB_NAME --log-level=warn --without-demo="" --db-filter=$DB_NAME -i ${DEPS_ADDONS}
+    if [ "$CREATE_DB_CACHE" != "false" ]; then
+        db_save $DB_NAME $DUMP
     fi
 fi
 echo "🔧🔧 Install local-src modules 🔧🔧"
-odoo --stop-after-init --workers=0 --database $DB_NAME_TEST --test-enable --log-level=test --log-handler=":INFO" --without-demo="" --db-filter=$DB_NAME_TEST -i ${LOCAL_ADDONS}
+odoo --stop-after-init --workers=0 --database $DB_NAME --test-enable --log-level=test --log-handler=":INFO" --without-demo="" --db-filter=$DB_NAME_TEST -i ${LOCAL_ADDONS}
 
-dropdb ${DB_NAME_TEST}
+dropdb ${DB_NAME}

--- a/bin/runtests
+++ b/bin/runtests
@@ -30,7 +30,7 @@ set -e
 
 wait_postgres.sh
 LOCAL_SRC_DIR=/odoo/local-src
-CACHE_DIR=/tmp
+CACHE_DIR=/tmp/cachedb
 
 if [ -z $1 ]; then
     LOCAL_ADDONS=$(find ${LOCAL_SRC_DIR}/* -maxdepth 0 -type d -and -not -name server_environment_files -printf "%f\n" |


### PR DESCRIPTION
Gives most variables a default value making them changable with `var=${var:=default}`

Extract db restore and dump in a separate db.sh file.

Change (default) value for cachedb directory to make it easier to set a volume on it.

Add `|| true` in runmigration when doing `ls -v` to ignore the error status and set an empty `CACHED_DUMP` variable.

Improve slightly the messages.  