### PR TITLE
[IMP] Modified entrypoint to add debugpy capabilities

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -114,6 +114,18 @@ if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ]; then
     run-parts --verbose "$START_ENTRYPOINT_DIR"
   fi
 
+  if [ ! -z "$DEBUGPY_ENABLE" ]; then
+    if [ -z "$DEBUGPY_PORT" ]; then
+      DEBUGPY_PORT=8888
+    fi
+    env python3 -m pip install debugpy pydevd-odoo
+    # TODO maybe we should set: GEVENT_SUPPORT=True
+    env python3 -m debugpy --listen 0.0.0.0:${DEBUGPY_PORT}  /usr/local/bin/odoo ${ARGS}
+  else
+    exec "$@"
+  fi
+  
+
   exec "$@"
 fi
 


### PR DESCRIPTION
With this modification you can use env variable to enable [debugpy](https://github.com/microsoft/debugpy) on a odoo container

DEBUGPY_ENABLE=1
DEBUGPY_PORT=[8888]

Once done, you just have to start you docker with -p 8888:8888 and use [vscode debugger](https://code.visualstudio.com/docs/python/debugging) ([quick demo](https://www.youtube.com/watch?v=ywfsLKRLmf4)) to connect the instance and start debuging


To test it in vscode, you'll need:

1. An entry in your launch.json file. Here is an example:


```json

{
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        
        {
            "name": "Python Debugger: Remote Attach",
            "type": "debugpy",
            "request": "attach",
            "connect": {
                "host": "localhost",
                "port": 8888
            },
            "pathMappings": [
                {
                    "localRoot": "${workspaceFolder}/odoo",
                    "remoteRoot": "/odoo"
                }
            ]
        },      
    ]
}
```

2. launch your project with the DEBUGPY_ENABLE variable set to 1
```bash
docker-compose -p bsuni-test-image  run -p 8069:8069 -p 8072:8072 -p 8888:8888 -e DEBUGPY_ENABLE=1 --rm --name=odoo odoo --workers=0 
```
3. Debug ;-)

![output](https://github.com/user-attachments/assets/b18167a2-9e52-4354-b500-4277b8aa3b56)


