### PR TITLE
Display installed addons before running tests in logs

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -66,6 +66,7 @@ else
         echo "No cached dump found matching MD5 🐢 🐢 🐢"
     fi
     echo "🔨🔨 Install official/OCA modules 🔨🔨"
+    echo "${DEPS_ADDONS}"
     odoo --stop-after-init --workers=0 --database $DB_NAME_TEST --log-level=warn --without-demo="" --db-filter=$DB_NAME_TEST -i ${DEPS_ADDONS}
     if [ "$CREATE_DB_CACHE" == "true" -a ! -z "$CACHED_DUMP" ]; then
         echo "Generate dump $CACHED_DUMP into cache 🐘⮕ 📦"


### PR DESCRIPTION
This will help a lot when having to debug a failing CI as it will allow to copy the list of installed addons to be able to reproduce locally.