### PR TITLE
Update marabunta version to 0.12.0

### DIFF
--- a/11.0/base_requirements.txt
+++ b/11.0/base_requirements.txt
@@ -64,7 +64,7 @@ simplejson==3.11.1
 urllib3==1.24.2
 
 # Migration tools
-marabunta==0.10.6
+marabunta==0.12.0
 anthem==0.13.0
 
 # test / lint

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -54,7 +54,7 @@ simplejson==3.18.0
 urllib3==1.26.11
 
 # Migration tools
-marabunta==0.10.6
+marabunta==0.12.0
 anthem==0.13.0
 
 # test / lint

--- a/13.0/base_requirements.txt
+++ b/13.0/base_requirements.txt
@@ -55,7 +55,7 @@ simplejson==3.18.0
 urllib3==1.26.11
 
 # Migration tools
-marabunta==0.10.6
+marabunta==0.12.0
 anthem==0.13.0
 
 # test / lint

--- a/14.0-bullseye/base_requirements.txt
+++ b/14.0-bullseye/base_requirements.txt
@@ -49,7 +49,7 @@ pyinotify==0.9.6
 simplejson==3.18.0
 urllib3==1.26.11
 
-marabunta==0.10.6
+marabunta==0.12.0
 anthem==0.13.0
 
 flake8

--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -49,7 +49,7 @@ pyinotify==0.9.6
 simplejson==3.18.0
 urllib3==1.26.11
 
-marabunta==0.10.6
+marabunta==0.12.0
 anthem==0.13.0
 
 flake8

--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -53,7 +53,7 @@ simplejson==3.18.0
 urllib3==1.26.11 
 
 # Migration tools
-marabunta==0.10.6
+marabunta==0.12.0
 -e git+https://github.com/camptocamp/anthem@master#egg=anthem
 
 # test / lint

--- a/16.0/base_requirements.txt
+++ b/16.0/base_requirements.txt
@@ -52,7 +52,7 @@ simplejson==3.17.6
 urllib3==1.26.7
 
 # Migration tools
-marabunta==0.10.6
+marabunta==0.12.0
 -e git+https://github.com/camptocamp/anthem@master#egg=anthem
 
 # test / lint

--- a/17.0/base_requirements.txt
+++ b/17.0/base_requirements.txt
@@ -52,7 +52,7 @@ simplejson==3.17.6
 urllib3==1.26.7
 
 # Migration tools
-marabunta==0.10.6
+marabunta==0.12.0
 -e git+https://github.com/camptocamp/anthem@master#egg=anthem
 
 # test / lint


### PR DESCRIPTION
Changes between 0.10.6 and 0.12.0

0.12.0 (2024-01-09)
+++++++++++++++++++

**Improvements**

* allow connecting to a local database server without password (using ident)


0.11.0 (2023-09-12)
+++++++++++++++++++

**Bugfixes**

* Fix the build and release workflow

**Build**

* Deprecate python 2.7, 3.5 and 3.6
* Support python 3.9, 3.10 and 3.11


0.10.7 (2022-05-24)
+++++++++++++++++++

**Bugfixes**

* Fix parsing of command line arguments (and related environment variables):
  ``--db-port``, ``--web-port``, ``--web-resp-status`` and
  ``--web-resp-retry-after``

**Improvements**

* Switch to Psycopg2 binary wheel

**Build**

* Test for python 3.6, 3.7 and 3.8