### PR TITLE
feat: add chromium to support odoo tests running in a browser

### DIFF
--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -27,7 +27,8 @@ ENV BUILD_PACKAGE \
     libjpeg-dev \
     libpng-dev \
     zlib1g-dev \
-    git
+    git \
+    chromium
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \

--- a/12.0/base_requirements.txt
+++ b/12.0/base_requirements.txt
@@ -79,6 +79,7 @@ coverage
 pytest-odoo
 pytest-cov
 watchdog
+websocket-client
 
 # Library dependency
 argh==0.26.2

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -27,7 +27,8 @@ ENV BUILD_PACKAGE \
     libjpeg-dev \
     libpng-dev \
     zlib1g-dev \
-    git
+    git \
+    chromium
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \

--- a/13.0/base_requirements.txt
+++ b/13.0/base_requirements.txt
@@ -76,6 +76,7 @@ coverage
 pytest-odoo
 pytest-cov
 watchdog
+websocket-client
 
 # Library dependency
 argh==0.26.2

--- a/14.0-bullseye/Dockerfile
+++ b/14.0-bullseye/Dockerfile
@@ -27,7 +27,8 @@ ENV BUILD_PACKAGE \
     libjpeg-dev \
     libpng-dev \
     zlib1g-dev \
-    git
+    git \
+    chromium
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \

--- a/14.0-bullseye/base_requirements.txt
+++ b/14.0-bullseye/base_requirements.txt
@@ -89,6 +89,7 @@ coverage
 pytest-odoo>=0.4.7
 pytest-cov>=2.10.0
 watchdog
+websocket-client
 
 # Library dependency
 argh==0.26.2

--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -27,7 +27,8 @@ ENV BUILD_PACKAGE \
     libjpeg-dev \
     libpng-dev \
     zlib1g-dev \
-    git
+    git \
+    chromium
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \

--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -82,6 +82,7 @@ coverage
 pytest-odoo>=0.4.7
 pytest-cov>=2.10.0
 watchdog
+websocket-client
 
 # Library dependency
 argh==0.26.2

--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -27,7 +27,8 @@ ENV BUILD_PACKAGE \
     libjpeg-dev \
     libpng-dev \
     zlib1g-dev \
-    git
+    git \
+    chromium
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 # wkhtml-buster is kept as in official image, no deb available for bullseye

--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -78,6 +78,7 @@ coverage
 pytest-odoo>=0.4.7
 pytest-cov>=2.10.0
 watchdog
+websocket-client
 
 # Library dependency
 argh==0.26.2

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -26,7 +26,8 @@ ENV BUILD_PACKAGE \
     libjpeg-dev \
     libpng-dev \
     zlib1g-dev \
-    git
+    git \
+    chromium
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 # wkhtml-buster is kept as in official image, no deb available for bullseye

--- a/16.0/base_requirements.txt
+++ b/16.0/base_requirements.txt
@@ -65,6 +65,7 @@ coverage
 pytest-odoo>=0.4.7
 pytest-cov>=2.10.0
 watchdog
+websocket-client
 
 # Library dependency
 argh==0.26.2

--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -26,7 +26,8 @@ ENV BUILD_PACKAGE \
     libjpeg-dev \
     libpng-dev \
     zlib1g-dev \
-    git
+    git \
+    chromium
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 # wkhtml-buster is kept as in official image, no deb available for bullseye

--- a/17.0/base_requirements.txt
+++ b/17.0/base_requirements.txt
@@ -68,6 +68,7 @@ coverage
 pytest-odoo>=0.4.7
 pytest-cov>=2.10.0
 watchdog
+websocket-client
 
 # Library dependency
 argh==0.26.2


### PR DESCRIPTION
Since [12.0](https://github.com/odoo/odoo/commit/de84ad9c1f4853cb8a748ee1d0c880081dae9fe2), odoo uses Chrome (Headless) instead of PhantomJS to run tests that needs a browser (e.g. Tour based tests for the POS).

On the OCA CI side, [Google Chrome is used](https://github.com/OCA/oca-ci/blob/f641d2587049ecd38637390f14db3bca3197a357/Dockerfile#L52).

But Odoo [also supports Chromium](https://github.com/odoo/odoo/blob/ba1ba88874e2ae9716e59ec199eb739d58c3f771/odoo/tests/common.py#L635), which is packaged in Debian.

So this PR adds `chromium` and the pip lib `websocket-client` that odoo uses to discuss with `chromium` through the Remote Debugging Protocol.

fyi:
```
$ apt show chromium | grep Installed-Size
Installed-Size: 235 MB
```