### PR TITLE
ci: only scan image on push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,7 @@ jobs:
         run: make VERSION=${{ matrix.odoo_serie }} test
 
       - name: Scan image
+        if: github.event_name == 'push'
         id: scan
         uses: sysdiglabs/scan-action@v5
         with:


### PR DESCRIPTION
Always scanning prevent contributors to contribute as in my understanding we can only pass this test having the secrets which is not the case on forks.

As this is a public repository it is important to keep it open to contributions.