### PR TITLE
imp: Replace environment variable OPENERP_SERVER with ODOO_RC

### DIFF
--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -75,7 +75,7 @@ ENV ODOO_VERSION=12.0 \
     ODOO_DATA_PATH=/odoo/data \
     DEMO=False \
     ADDONS_PATH=/odoo/odoo/addons,/odoo/odoo/src/odoo/addons \
-    OPENERP_SERVER=/odoo/odoo.cfg
+    ODOO_RC=/odoo/odoo.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -74,7 +74,7 @@ ENV ODOO_VERSION=13.0 \
     ODOO_DATA_PATH=/odoo/data \
     DEMO=False \
     ADDONS_PATH=/odoo/odoo/addons,/odoo/odoo/src/odoo/addons \
-    OPENERP_SERVER=/odoo/odoo.cfg
+    ODOO_RC=/odoo/odoo.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]

--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -75,7 +75,7 @@ ENV ODOO_VERSION=14.0 \
     ODOO_DATA_PATH=/odoo/data \
     DEMO=False \
     ADDONS_PATH=/odoo/local-src,/odoo/src/addons \
-    OPENERP_SERVER=/odoo/odoo.cfg
+    ODOO_RC=/odoo/odoo.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]

--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -75,7 +75,7 @@ ENV ODOO_VERSION=15.0 \
     ODOO_DATA_PATH=/odoo/data \
     DEMO=False \
     ADDONS_PATH=/odoo/odoo/addons,/odoo/odoo/src/odoo/addons \
-    OPENERP_SERVER=/odoo/odoo.cfg
+    ODOO_RC=/odoo/odoo.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -75,7 +75,7 @@ ENV ODOO_VERSION=16.0 \
     ODOO_DATA_PATH=/odoo/data \
     DEMO=False \
     ADDONS_PATH=/odoo/odoo/addons,/odoo/odoo/src/odoo/addons \
-    OPENERP_SERVER=/odoo/odoo.cfg
+    ODOO_RC=/odoo/odoo.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]

--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -75,7 +75,7 @@ ENV ODOO_VERSION=17.0 \
     ODOO_DATA_PATH=/odoo/data \
     DEMO=False \
     ADDONS_PATH=/odoo/odoo/addons,/odoo/odoo/src/odoo/addons \
-    OPENERP_SERVER=/odoo/odoo.cfg
+    ODOO_RC=/odoo/odoo.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]

--- a/18.0/Dockerfile
+++ b/18.0/Dockerfile
@@ -75,7 +75,7 @@ ENV ODOO_VERSION=18.0 \
     ODOO_DATA_PATH=/odoo/data \
     DEMO=False \
     ADDONS_PATH=/odoo/odoo/addons,/odoo/odoo/src/odoo/addons \
-    OPENERP_SERVER=/odoo/odoo.cfg
+    ODOO_RC=/odoo/odoo.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["odoo"]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@
 
 .. **Features and Improvements**
 
+* Replace environment variable OPENERP_SERVER with ODOO_RC
+
 .. **Bugfixes**
 
 .. **Libraries**


### PR DESCRIPTION
It's the officially supported way to point to the config file since Odoo 10.0. OPENERP_SERVER will be officially deprecated in Odoo 19.0.

See: https://github.com/odoo/odoo/blob/4185fe84/odoo/tools/config.py#L464