### PR TITLE
[FIX] disable openblas threads

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -61,6 +61,7 @@ ENV ODOO_VERSION=11.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -60,6 +60,7 @@ ENV ODOO_VERSION=12.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -60,6 +60,7 @@ ENV ODOO_VERSION=13.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \

--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -60,6 +60,7 @@ ENV ODOO_VERSION=14.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \

--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -61,6 +61,7 @@ ENV ODOO_VERSION=15.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -61,6 +61,7 @@ ENV ODOO_VERSION=16.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \

--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -61,6 +61,7 @@ ENV ODOO_VERSION=17.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \

--- a/18.0/Dockerfile
+++ b/18.0/Dockerfile
@@ -61,6 +61,7 @@ ENV ODOO_VERSION=18.0 \
     PATH=/odoo-bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
+    OPENBLAS_NUM_THREADS=1 \
     DB_HOST=db \
     DB_PORT=5432 \
     DB_NAME=odoodb \


### PR DESCRIPTION
When numpy is imported, it will load some dependencies, if they are available. One of these is openblas, which will start some threads, which we will not be using, but which are consuming precious memory resources. By setting the OPENBLAS_NUM_THREADS environment variable to 1, we disable the creation of these threads and therefore reduce the memory usage of the Odoo workers.

This fixes the memory consumption issue when ninja dashboard is installed.