### PR TITLE
[FIX] add missing requirement for guessing mimetype

### DIFF
--- a/17.0/extra_requirements.txt
+++ b/17.0/extra_requirements.txt
@@ -38,6 +38,7 @@ pycparser==2.22
 pycryptodome==3.20.0
 PyNaCl==1.5.0
 pytesseract==0.3.13
+python3-magic
 regex==2024.7.24
 s3transfer==0.10.2
 tzlocal==5.2

--- a/18.0/extra_requirements.txt
+++ b/18.0/extra_requirements.txt
@@ -38,6 +38,7 @@ pycparser==2.22
 pycryptodome==3.20.0
 PyNaCl==1.5.0
 pytesseract==0.3.13
+python3-magic
 regex==2024.7.24
 s3transfer==0.10.2
 tzlocal==5.2


### PR DESCRIPTION
It is widely used in odoo to work around the mimetypes.
It was installed for `odoo-dj` into `odoo-template`.

I want to have it removed from odoo-template and added into the base images.