### PR TITLE
[FIX] runtests: Ignore base_automation from dependencies

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -40,7 +40,10 @@ else
     LOCAL_ADDONS=$1
 fi
 
-DEPS_ADDONS=$(list_dependencies.py "$LOCAL_ADDONS")
+ALL_DEPS_ADDONS=$(list_dependencies.py "$LOCAL_ADDONS")
+# Ignore base_automation from dependencies to avoid its register hook
+#  messing with MRO of modules to be installed after server restart
+DEPS_ADDONS=${ALL_DEPS_ADDONS/",base_automation,"/","}
 
 DB_NAME_TEST=${DB_NAME}_test
 


### PR DESCRIPTION
When base_automation appears in the dependencies, the register hook from this module will be executed before any local module will be installed, potentially messing with MRO of models overriden in local modules that are not installed yet.