### PR TITLE
imp: run-parts exit on error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@
 .. **Features and Improvements**
 
 * Replace environment variable OPENERP_SERVER with ODOO_RC
+* Entrypoint: exit on error when executing run-parts
 
 .. **Bugfixes**
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -95,7 +95,7 @@ ARGS=(${CMD_ARRAY[@]:1})
 if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] || [ "$BASE_CMD" = "migrate" ]; then
   BEFORE_MIGRATE_ENTRYPOINT_DIR=/odoo/before-migrate-entrypoint.d
   if [ -d "$BEFORE_MIGRATE_ENTRYPOINT_DIR" ]; then
-    run-parts --verbose "$BEFORE_MIGRATE_ENTRYPOINT_DIR"
+    run-parts --exit-on-error --verbose "$BEFORE_MIGRATE_ENTRYPOINT_DIR"
   fi
 fi
 if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ]; then
@@ -111,7 +111,7 @@ if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ]; then
 
   START_ENTRYPOINT_DIR=/odoo/start-entrypoint.d
   if [ -d "$START_ENTRYPOINT_DIR" ]; then
-    run-parts --verbose "$START_ENTRYPOINT_DIR"
+    run-parts --exit-on-error --verbose "$START_ENTRYPOINT_DIR"
   fi
 
   exec "$@"


### PR DESCRIPTION
In case of error in a one of the parts/scripts, exit immediately.

Without this, the other parts will be executed, but it will still return an error code and so the docker-entrypoint.sh will immediately exit, too.

This way, though, it's easier to stop where the error is.


Motivated by:
-  https://github.com/camptocamp/docker-odoo-core/pull/302