### PR TITLE
[FIX] 19.0: remove pdfminer

### DIFF
--- a/18.0/extra_requirements.txt
+++ b/18.0/extra_requirements.txt
@@ -37,5 +37,3 @@ s3transfer==0.10.2
 tzlocal==5.2
 yarl==1.22.0
 
-#Extra for enterprise
-pdfminer==20191125

--- a/19.0/extra_requirements.txt
+++ b/19.0/extra_requirements.txt
@@ -37,5 +37,3 @@ s3transfer==0.14.0
 tzlocal==5.3.1
 yarl==1.22.0
 
-#Extra for enterprise
-pdfminer==20191125


### PR DESCRIPTION
pdfminer is old, unmaintained, and replaces by pdfminer.six which is already included