### PR TITLE
refactor: remove deprecated DEMO parameter values from entrypoint

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -55,17 +55,6 @@ case "$(echo "${DEMO:-false}" | tr '[:upper:]' '[:lower:]')" in
     echo "Running with demo data"
     export DEMO=True WITHOUT_DEMO=
     ;;
-  # deprecated options:
-  "odoo")
-    echo "Running with demo data"
-    echo "DEMO=odoo is deprecated, use DEMO=True"
-    export DEMO=True WITHOUT_DEMO=
-    ;;
-  "none")
-    echo "Running without demo data"
-    echo "DEMO=none is deprecated, use DEMO=False"
-    export DEMO=False WITHOUT_DEMO=all
-    ;;
   *)
     echo "Value '${DEMO}' for DEMO is not a valid value in 'False', 'True'"
     exit 1


### PR DESCRIPTION
Remove legacy DEMO values (`odoo`, `none`, `scenario`, `all`) that have been deprecated for > 10 years (https://github.com/camptocamp/docker-odoo-project/commit/28826e07669c797acdfe31146f7de4dc9c046c3a).