### PR TITLE
ci: add Dockerfile linting with Hadolint

### DIFF
--- a/.github/workflows/hadolint.yaml
+++ b/.github/workflows/hadolint.yaml
@@ -1,0 +1,21 @@
+name: hadolint
+
+on:
+  push:
+    branches:
+      - "release-4.5.X"
+      - "dev-4.5.X"
+  pull_request:
+    branches:
+      - "release-4.5.X"
+
+jobs:
+
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint Dockerfiles
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          recursive: true

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,15 @@
+# Hadolint configuration
+# https://github.com/hadolint/hadolint#configure
+
+ignored:
+  # Pin versions in apt-get install: package installation is delegated to
+  # install/*.sh scripts, pinning isn't practical for base images.
+  - DL3008
+  # Pin versions in pip install: handled via requirements.txt files.
+  - DL3013
+  # Avoid cache directory with pip: cache is cleaned by
+  # install/purge_dev_package_and_cache.sh.
+  - DL3042
+  # Last USER should not be root: the entrypoint uses gosu to step down
+  # from root, so running as root at build time is intentional.
+  - DL3002

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.7-slim-bookworm
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.9-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.9-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.9-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.12-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.12-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.12-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/18.0/Dockerfile
+++ b/18.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.12-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/19.0/Dockerfile
+++ b/19.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.12-slim-trixie
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo
 
-COPY ./base_requirements.txt ./platform_requirements.txt /odoo
+COPY ./base_requirements.txt ./platform_requirements.txt /odoo/
 COPY ./install /install
 
 # Moved because there was a bug while installing `odoo-autodiscover`. There is

--- a/common/Dockerfile-batteries
+++ b/common/Dockerfile-batteries
@@ -1,4 +1,4 @@
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 WORKDIR "/odoo"
 COPY ./extra_requirements.txt ./

--- a/example/odoo/Dockerfile
+++ b/example/odoo/Dockerfile
@@ -1,5 +1,5 @@
 FROM ci-latest:0.1
-MAINTAINER Camptocamp
+LABEL maintainer="Camptocamp"
 
 # For installing odoo you have two possibility
 # 1. either adding the whole root directory
@@ -16,20 +16,18 @@ COPY ./setup.py /odoo/
 COPY ./VERSION /odoo/
 COPY ./migration.yml /odoo/
 
+COPY ./requirements.txt /odoo/
+
 USER root
-RUN pip install -e /odoo
-
-RUN pip install -e /odoo/src
-
-# Project's specifics packages
 RUN set -x; \
-        apt-get update \
+        pip install -e /odoo \
+        && pip install -e /odoo/src \
+        # Project's specifics packages
+        && apt-get update \
         && apt-get install -y --no-install-recommends \
         python3-shapely \
         && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*
-
-COPY ./requirements.txt /odoo/
-RUN cd /odoo && pip install -r requirements.txt
+        && rm -rf /var/lib/apt/lists/* \
+        && pip install -r /odoo/requirements.txt
 
 ENV ADDONS_PATH=/odoo/local-src,/odoo/src/addons


### PR DESCRIPTION
Add Hadolint to CI and pre-commit to catch Dockerfile issues automatically.

Fixes for existing Dockerfile issues found by Hadolint:
- Replace deprecated MAINTAINER with LABEL maintainer= (DL4000)
- Add trailing slash to multi-arg COPY destinations (DL3021)
- Consolidate consecutive RUN instructions in example (DL3059)
- Use WORKDIR instead of cd in example (DL3003)