### PR TITLE
feat: do not pre-install Postgres client 17

### DIFF
--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -35,7 +35,7 @@ ENV BUILD_PACKAGE="\
 RUN set -x; \
     /install/package_odoo.sh \
     && /install/setup-pip.sh \
-    && /install/postgres.sh \
+    && /install/postgres.sh 15 \
     && /install/kwkhtml_client.sh \
     && /install/kwkhtml_client_force_python3.sh \
     && /install/dev_package.sh \

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -35,7 +35,7 @@ ENV BUILD_PACKAGE="\
 RUN set -x; \
     /install/package_odoo.sh \
     && /install/setup-pip.sh \
-    && /install/postgres.sh \
+    && /install/postgres.sh 15 \
     && /install/kwkhtml_client.sh \
     && /install/kwkhtml_client_force_python3.sh \
     && /install/dev_package.sh \

--- a/README.md
+++ b/README.md
@@ -76,12 +76,17 @@ You can also see the Dockerfile that generated this image here: [common/Dockerfi
 The images should be built with `make`:
 
 Normal flavors:
-
 ```
 $ make VERSION=19.0
 ```
 
-Batteries-included flavors:
+Note: version of PostgreSQL client can be changed.  By default, it is version 15, which is fully
+compatible with PostgreSQL 12 to 15. Example:
+```
+$ make VERSION=19.0 PG_VERSION=17
+```
+
+Batteries-included flavor:
 ```
 $ make VERSION=19.0 BATTERIES=True
 ```

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -3,6 +3,7 @@ FROM python
 LABEL maintainer="Camptocamp"
 
 ARG VERSION=19.0
+ARG PG_VERSION=15
 
 # create the working directory and a place to set the logs (if wanted)
 RUN mkdir -p /odoo /var/log/odoo

--- a/common/core.Dockerfile
+++ b/common/core.Dockerfile
@@ -3,6 +3,7 @@ FROM python
 LABEL maintainer="Camptocamp"
 
 ARG VERSION=19.0
+ARG PG_VERSION=15
 ARG UID=999
 ARG GID=999
 

--- a/install/postgres.sh
+++ b/install/postgres.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
-PSQL_VERSION=17
+if [ -n "${PG_VERSION=${1-}}" ]; then
+  POSTGRES_PACKAGE="postgresql-client-$PG_VERSION"
+else
+  POSTGRES_PACKAGE="postgresql-client-common libpq5"
+fi
 
 OS_CODENAME=$(awk -F= '$1=="VERSION_CODENAME" { print $2 ;}' /etc/os-release)
 APT_REPO="apt.postgresql.org"
@@ -10,5 +14,5 @@ echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/postgresql.asc] http://${APT_R
 curl https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/keyrings/postgresql.asc
 
 apt-get update
-apt-get install -y --no-install-recommends postgresql-client-${PSQL_VERSION} libpq-dev
-apt-get -y install -f --no-install-recommends
+apt-get install -y --no-install-recommends $POSTGRES_PACKAGE libpq-dev
+apt-get install -y --no-install-recommends --fix-broken


### PR DESCRIPTION
Archive format generated with version 17 is not compatible with PG 14.

In brief:
- PostgreSQL client 12 to 15 are compatible together (archive format v1.14)
- PostgreSQL client 16 produces archive v1.15 (and read all previous)
- PostgreSQL client 17 and 18 produce archive v1.16 (and read older)

This change partially reverts:
- #418 

Reference:
- https://github.com/postgres/postgres/blob/REL_18_STABLE/src/bin/pg_dump/pg_backup_archiver.h#L67

Trick, to print the headers of a PG dump:
```sh
$ pg_restore -ln- path/to/database-dump.pg
;
; Archive created at 2026-02-03 18:41:36 CET
;     dbname: broken_shadow_592
;     TOC Entries: 17387
;     Compression: gzip
;     Dump Version: 1.14-0
;     Format: CUSTOM
;     Integer: 4 bytes
;     Offset: 8 bytes
;     Dumped from database version: 14.19
;     Dumped by pg_dump version: 14.17
;
;
; Selected TOC Entries:
;
```