### PR TITLE
(experiment) feat: use Bake GH action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,18 +85,18 @@ jobs:
           echo "image-tag=ci-${{ matrix.flavor == 'core' && '5' || '4' }}xx-latest:${{ matrix.odoo_serie }}" >> $GITHUB_OUTPUT
 
       - name: Build
-        uses: docker/build-push-action@v7
+        uses: docker/bake-action@v7
         with:
-          context: ./build
-          file: ${{ steps.setup.outputs.Dockerfile }}
-          build-args: |
-            VERSION=${{ matrix.odoo_serie }}
-          build-contexts: |
-            python=docker-image://${{ steps.setup.outputs.python-from }}
+          source: ./build
+          targets: odoo-project-${{ matrix.flavor }}
+          files: |
+            compose.yaml
+            cwd://${{ steps.docker_meta.outputs.bake-file }}
           push: false
           load: true
-          tags: ${{ steps.setup.outputs.image-tag  }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+        env:
+          VERSION: ${{ matrix.odoo_serie }}
+          PYTHON_IMAGE: ${{ steps.setup.outputs.python-from }}
 
       - name: Test
         run: |

--- a/common/compose.yaml
+++ b/common/compose.yaml
@@ -1,0 +1,36 @@
+# To use with `docker buildx bake`
+services:
+
+  odoo-project-main:
+    image: odoo:${VERSION}
+    build: &build-main
+      dockerfile: ./Dockerfile
+      additional_contexts:
+        - python=docker-image://${PYTHON_IMAGE}
+      args:
+        VERSION: ${VERSION}
+      x-bake:
+        tags:
+          - ci-4xx-latest:${VERSION}
+
+  odoo-project-core:
+    image: odoo:${VERSION}-core
+    build:
+      <<: *build-main
+      dockerfile: ./core.Dockerfile
+      x-bake:
+        tags:
+          - ci-5xx-latest:${VERSION}
+
+  odoo-project-batteries:
+    image: odoo:${VERSION}-batteries
+    build:
+      <<: *build-main
+      dockerfile: ./batteries.Dockerfile
+      additional_contexts:
+        - odoo=docker-image://odoo:${VERSION}
+      x-bake:
+        tags:
+          - ci-4xx-batteries-latest:${VERSION}
+    depends_on:
+      - odoo-project-main


### PR DESCRIPTION
Incomplete change.

- Implementation of the `docker/bake-action` action for "Build" step only.
- Step "Tag &  Push" is still using `docker/build-push-action`.
