### PR TITLE
feat: remove BUILD_PACKAGE env var from the container

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
           - odoo_serie: "14.0"
             python: "python:3.9"
             flavor: core
-    continue-on-error: ${{ matrix.odoo_serie == '12.0' || matrix.flavor == 'core' }}
+    continue-on-error: ${{ matrix.odoo_serie == '12.0' || matrix.odoo_serie == '13.0' || matrix.flavor == 'core' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -15,22 +15,6 @@ COPY ./install /install
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-# build and dev packages
-ENV BUILD_PACKAGE="\
-    build-essential \
-    gcc \
-    libevent-dev \
-    libfreetype6-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libsasl2-dev \
-    libldap2-dev \
-    libssl-dev \
-    libjpeg-dev \
-    libpng-dev \
-    zlib1g-dev \
-    git"
-
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
     /install/package_odoo.sh \

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -15,22 +15,6 @@ COPY ./install /install
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-# build and dev packages
-ENV BUILD_PACKAGE="\
-    build-essential \
-    gcc \
-    libevent-dev \
-    libfreetype6-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libsasl2-dev \
-    libldap2-dev \
-    libssl-dev \
-    libjpeg-dev \
-    libpng-dev \
-    zlib1g-dev \
-    git"
-
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
     /install/package_odoo.sh \

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -37,6 +37,10 @@ RUN /install/package_odoo.sh \
 # grab gosu for easy step-down from root and dockerize to generate template and
 # wait on postgres
 RUN /install/gosu.sh && /install/dockerize.sh
+# Init PG variables during Shell initialization so it will be available
+# when doing 'docker compose exec odoo gosu odoo bash'
+RUN echo >> /etc/bash.bashrc \
+  "if [ -f /odoo-bin/env_postgres.sh ]; then . /odoo-bin/env_postgres.sh; fi"
 
 COPY ./bin /odoo-bin
 COPY ./templates /templates
@@ -44,10 +48,6 @@ COPY ./before-migrate-entrypoint.d /before-migrate-entrypoint.d
 COPY ./start-entrypoint.d /start-entrypoint.d
 COPY ./MANIFEST.in /odoo
 COPY --chmod=644 ./env_odoo.sh /odoo-bin/
-# Init PG variables during Shell initialization so it will be available
-# when doing 'docker compose exec odoo gosu odoo bash'
-RUN set -x; echo >> /etc/bash.bashrc \
-  "if [ -f /odoo-bin/env_postgres.sh ]; then . /odoo-bin/env_postgres.sh; fi"
 
 ENV ODOO_VERSION=$VERSION \
     PATH=/odoo-bin:$PATH \

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -16,24 +16,6 @@ COPY ./*_requirements.txt /odoo/
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-# build and dev packages
-ENV BUILD_PACKAGE="\
-    build-essential \
-    gcc \
-    libevent-dev \
-    libfreetype6-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libsasl2-dev \
-    libldap2-dev \
-    libssl-dev \
-    libjpeg-dev \
-    libpng-dev \
-    zlib1g-dev \
-    libcairo2-dev \
-    git"
-
-
 # Default SHELL is ["/bin/sh", "-c"]
 SHELL ["/bin/sh", "-e", "-x", "-c"]
 
@@ -44,6 +26,7 @@ RUN /install/package_odoo.sh \
     && /install/postgres.sh \
     && /install/kwkhtml_client.sh \
     && /install/kwkhtml_client_force_python3.sh \
+    # build and dev packages
     && /install/dev_package.sh \
     && python3 -m pip install --force-reinstall pip \
     && pip install -r /odoo/base_requirements.txt \

--- a/common/core.Dockerfile
+++ b/common/core.Dockerfile
@@ -57,6 +57,10 @@ RUN /install/package_odoo.sh core \
     && /install/dockerize.sh \
     # Purge build packages, to reduce layer size
     && /install/purge_dev_package_and_cache.sh
+# Init PG variables during Shell initialization so it will be available
+# when doing 'docker compose exec odoo bash'
+RUN echo >> /etc/bash.bashrc \
+  "if [ -f /odoo-bin/env_postgres.sh ]; then . /odoo-bin/env_postgres.sh; fi"
 
 COPY --chown=odoo:root --chmod=770 ./bin /odoo/odoo-bin
 COPY --chown=odoo:root --chmod=660 ./templates /templates
@@ -64,10 +68,6 @@ COPY --chown=odoo:root --chmod=770 ./before-migrate-entrypoint.d /odoo/before-mi
 COPY --chown=odoo:root --chmod=770 ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY --chown=odoo:root --chmod=660 ./MANIFEST.in /odoo
 COPY --chmod=644 ./env_odoo-core.sh /odoo/odoo-bin/env_odoo.sh
-# Init PG variables during Shell initialization so it will be available
-# when doing 'docker compose exec odoo bash'
-RUN set -x; echo >> /etc/bash.bashrc \
-  "if [ -f /odoo-bin/env_postgres.sh ]; then . /odoo-bin/env_postgres.sh; fi"
 
 
 USER odoo

--- a/common/core.Dockerfile
+++ b/common/core.Dockerfile
@@ -34,22 +34,6 @@ ENV LANG=C.UTF-8 \
     PATH=/odoo/.venv/bin:$PATH \
     PYTHONPATH=/odoo/
 
-# build and dev packages
-ENV BUILD_PACKAGE="\
-    build-essential \
-    gcc \
-    libevent-dev \
-    libfreetype6-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libsasl2-dev \
-    libldap2-dev \
-    libssl-dev \
-    libjpeg-dev \
-    libpng-dev \
-    zlib1g-dev \
-    libcairo2-dev"
-
 
 # Default SHELL is ["/bin/sh", "-c"]
 SHELL ["/bin/sh", "-e", "-x", "-c"]
@@ -61,7 +45,8 @@ RUN /install/package_odoo.sh core \
     && /install/postgres.sh \
     && /install/kwkhtml_client.sh \
     && /install/kwkhtml_client_force_python3.sh \
-    && /install/dev_package.sh \
+    # build and dev packages
+    && /install/dev_package.sh core \
     && su odoo -c "umask 007 \
     && python3 -m venv /odoo/.venv --system-site-packages \
     && /odoo/.venv/bin/pip install -r /odoo/base_requirements.txt \

--- a/example-core/Dockerfile
+++ b/example-core/Dockerfile
@@ -19,14 +19,12 @@ COPY ./migration.yml /odoo/
 USER root
 # RUN apt-get update \
 #     && apt-get install -y --no-install-recommends parallel  libsasl2-dev libldap2-dev libssl-dev libmagic1 libpq-dev build-essential python3-dev libffi-dev pkg-config libcairo2-dev libgirepository1.0-dev\
-#     && apt-get clean \
 #     && rm -rf /var/lib/apt/lists/*
 
 # RUN set -x; \
 #         apt-get update \
 #         && apt-get install -y --no-install-recommends \
 #         python3-shapely \
-#         && apt-get clean \
 #         && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /odoo/

--- a/example/odoo/Dockerfile
+++ b/example/odoo/Dockerfile
@@ -19,14 +19,13 @@ COPY ./migration.yml /odoo/
 COPY ./requirements.txt /odoo/
 
 USER root
-RUN set -x; \
+RUN \
         pip install -e /odoo \
         && pip install -e /odoo/src \
-        # Project's specifics packages
+        # Project's specific packages
         && apt-get update \
         && apt-get install -y --no-install-recommends \
         python3-shapely \
-        && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
         && pip install -r /odoo/requirements.txt
 

--- a/install/apt_purge.sh
+++ b/install/apt_purge.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eo pipefail
+
+if [ -n "${_PACKAGES_TO_REMOVE=$@}" ]; then
+  apt-get remove -y "$_PACKAGES_TO_REMOVE"
+fi
+
+apt-get purge -y --auto-remove \
+  -o APT::AutoRemove::RecommendsImportant=false \
+  -o APT::AutoRemove::SuggestsImportant=false
+
+# Note: `apt-get clean` is done already:
+# - /etc/apt/apt.conf.d/docker-clean
+
+rm -rf /var/lib/apt/lists/*

--- a/install/dev_package.sh
+++ b/install/dev_package.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
 set -eo pipefail
 
+# These packages are installed in order to build dependencies.
+# They are uninstalled right after with 'purge_dev_package_and_cache.sh'
+
+export BUILD_PACKAGE="\
+    build-essential \
+    gcc \
+    libcairo2-dev \
+    libevent-dev \
+    libfreetype6-dev \
+    libjpeg-dev \
+    libldap2-dev \
+    libpng-dev \
+    libsasl2-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    zlib1g-dev \
+"
+
+if [ "${1-}" != "core" ]; then
+  BUILD_PACKAGE="$BUILD_PACKAGE git"
+fi
+
 apt-get update
 apt-get install -y --no-install-recommends $BUILD_PACKAGE

--- a/install/purge_dev_package_and_cache.sh
+++ b/install/purge_dev_package_and_cache.sh
@@ -8,3 +8,5 @@ rm -rf /var/lib/apt/lists/* /root/.cache/pip/*
 # Remove METADATA of vendored dependencies
 # which triggered a vulnerability report, without easy way to fix it.
 rm -vrf /odoo/.venv/lib/python3*/site-packages/setuptools/_vendor/*.dist-info
+
+unset $BUILD_PACKAGE

--- a/install/purge_dev_package_and_cache.sh
+++ b/install/purge_dev_package_and_cache.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 set -eo pipefail
+# Note: Python pip cache is disabled by install/setup-pip.sh
 
-apt-get remove -y $BUILD_PACKAGE libpq-dev
-apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $PURGE_PACKAGE
-rm -rf /var/lib/apt/lists/* /root/.cache/pip/*
+/install/apt_purge.sh $BUILD_PACKAGE libpq-dev
+
+if [ ! -d "${LIB_PATH:=/odoo/.venv/lib}" ]; then
+  LIB_PATH=/usr/local/lib
+fi
 
 # Remove METADATA of vendored dependencies
 # which triggered a vulnerability report, without easy way to fix it.
-rm -vrf /odoo/.venv/lib/python3*/site-packages/setuptools/_vendor/*.dist-info
+rm -vrf $LIB_PATH/python3*/site-packages/setuptools/_vendor/*.dist-info
 
 unset $BUILD_PACKAGE


### PR DESCRIPTION
Enhancements on the side of package clean-up:
- do not expose `BUILD_PACKAGE` in the image environment
- split `apt-get purge` in a shell script, for re-use in project's image
- fix, to apply `site-packages/setuptools/_vendor` clean-up for the main image as well (it was working only for `core`)
- remove unnecessary `/root/.cache/pip` clean-up:  pip cache is disabled globally