### PR TITLE
[FIX] Do not compare value when checking if 'database.is_neutralized'

### DIFF
--- a/start-entrypoint.d/002_neutralize
+++ b/start-entrypoint.d/002_neutralize
@@ -11,7 +11,7 @@ if [[ "$RUNNING_ENV" != "prod" && "$ODOO_NEUTRALIZE" == "True" ]]; then
         echo "Database does not exist, ignoring script"
         exit 0
     fi
-    if [ "$( psql -tAc "SELECT value FROM ir_config_parameter WHERE key='database.is_neutralized'" )" = 'True' ]; then
+    if [ "$( psql -tAc "SELECT 1 FROM ir_config_parameter WHERE key='database.is_neutralized' AND value != '';" )" = '1' ]; then
         echo "Database is already neutralized, skipping"
         exit 0
     fi

--- a/start-entrypoint.d/003_confidoo_apply
+++ b/start-entrypoint.d/003_confidoo_apply
@@ -21,7 +21,7 @@ if [[ "$RUNNING_ENV" != "prod" && "$CONFIDOO_APPLY" == "True" ]]; then
         echo "Error: 'confidoo' command not found. Please ensure it is installed in the image."
         exit 1
     fi
-    if [ "$( psql -tAc "SELECT value FROM ir_config_parameter WHERE key='database.is_neutralized'" )" != 'True' ]; then
+    if [ "$( psql -tAc "SELECT 1 FROM ir_config_parameter WHERE key='database.is_neutralized' AND value != '';" )" = '1' ]; then
         echo "INFO: You are about to apply Confidoo settings on a non-neutralized database."
     fi
 


### PR DESCRIPTION
odoo neutralize set this parameter to true (see below).
Instead of checking if the value is True, as we did, we can only check if the parameter exists to not care about its exact value.
```
-- neutralization flag for the database
INSERT INTO ir_config_parameter (key, value)
VALUES ('database.is_neutralized', true)
    ON CONFLICT (key) DO
       UPDATE SET value = true;
```