### PR TITLE
fix: remove obsolete simplejson dependency

### DIFF
--- a/14.0/base_requirements.txt
+++ b/14.0/base_requirements.txt
@@ -54,7 +54,6 @@ gdata==2.0.18
 html5lib==1.1
 odfpy==1.4.1
 pyinotify==0.9.6
-simplejson==3.19.3
 
 
 # Migration tools

--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -51,7 +51,6 @@ gdata==2.0.18
 html5lib==1.1
 odfpy==1.4.1
 pyinotify==0.9.6
-simplejson==3.19.3
 
 
 # Migration tools

--- a/16.0/base_requirements.txt
+++ b/16.0/base_requirements.txt
@@ -54,7 +54,6 @@ gdata==2.0.18
 html5lib==1.1
 odfpy==1.4.1
 pyinotify==0.9.6
-simplejson==3.19.3
 
 
 # Migration tools

--- a/17.0/base_requirements.txt
+++ b/17.0/base_requirements.txt
@@ -55,7 +55,6 @@ gdata==2.0.18
 html5lib==1.1
 odfpy==1.4.1
 pyinotify==0.9.6
-simplejson==3.19.3
 orjson==3.11.9  # used to speed up addons/bus if installed
 
 

--- a/18.0/base_requirements.txt
+++ b/18.0/base_requirements.txt
@@ -57,8 +57,8 @@ gdata==2.0.18
 html5lib==1.1
 odfpy==1.4.1
 pyinotify==0.9.6
-simplejson==3.19.3
 orjson==3.11.9  # used to speed up addons/bus if installed
+
 
 # Migration tools
 marabunta==0.14.0

--- a/19.0/base_requirements.txt
+++ b/19.0/base_requirements.txt
@@ -60,8 +60,8 @@ gdata==2.0.18
 html5lib==1.1
 odfpy==1.4.1
 pyinotify==0.9.6
-simplejson==3.20.1
 orjson==3.11.9  # used to speed up addons/bus if installed
+
 
 # Migration tools
 # marabunta==0.13.0


### PR DESCRIPTION
This was removed upstream in Odoo 9: 
- odoo/odoo#6940

And keeping 'simplejson' around can have side effects:
- odoo/odoo#264303

(see also #447)