### PR TITLE
fix: pytest-odoo 2.1.3 is not compatible with Odoo 14/15

### DIFF
--- a/14.0/test_requirements.txt
+++ b/14.0/test_requirements.txt
@@ -5,6 +5,7 @@ flake8
 pytest==8.3.2
 pluggy
 coverage
-pytest-odoo>=0.4.7
+# Pin, because 2.1.4 with camptocamp/pytest-odoo#85 is not released
+pytest-odoo==2.1.2
 pytest-cov>=2.10.0
 watchdog

--- a/15.0/test_requirements.txt
+++ b/15.0/test_requirements.txt
@@ -5,6 +5,7 @@ flake8
 pytest==8.3.2
 pluggy
 coverage
-pytest-odoo>=0.4.7
+# Pin, because 2.1.4 with camptocamp/pytest-odoo#85 is not released
+pytest-odoo==2.1.2
 pytest-cov>=2.10.0
 watchdog


### PR DESCRIPTION
It is about:
- camptocamp/pytest-odoo#82  fix for Odoo 18, landed in 2.1.3
- camptocamp/pytest-odoo#84  regression detected on Odoo 14
- camptocamp/pytest-odoo#85  fix which is not released yet