### PR TITLE
fix(apt_purge): pass packages as separate args to apt-get remove

### DIFF
--- a/install/apt_purge.sh
+++ b/install/apt_purge.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
-if [ -n "${_PACKAGES_TO_REMOVE=$@}" ]; then
-  apt-get remove -y "$_PACKAGES_TO_REMOVE"
+if [ $# -gt 0 ]; then
+  apt-get remove -y "$@"
 fi
 
 apt-get purge -y --auto-remove \


### PR DESCRIPTION
`$@` inside a double-quoted default-assignment `${var=$@}` is joined into a single string, causing `apt-get remove` to receive all package names as one argument instead of individual ones.
Replace the pattern with a plain argument-count check (`$# -gt 0`) and pass `"$@"` directly so each package remains a separate word.