### PR TITLE
ci: remove parasite image tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,14 +67,14 @@ jobs:
           flavor: |
             prefix=${{ matrix.odoo_serie }}${{ matrix.flavor == 'core' && '-core-' || '-' }},onlatest=true
           tags: |
-            type=ref,event=tag,priority=900,enable=true
+            type=ref,priority=900,event=tag,enable=true
             type=ref,event=pr
             type=schedule,priority=800
             type=raw,priority=500,value=latest,enable={{is_default_branch}}
             type=raw,priority=400,value={{date 'YYYYMMDD'}},enable={{is_default_branch}}
-            type=raw,priority=300,value={{branch}}-latest,enable={{is_not_default_branch}}
-            type=raw,priority=300,value={{branch}}-{{date 'YYYYMMDD'}},enable={{is_not_default_branch}}
-            type=raw,priority=200,value={{branch}},enable={{is_not_default_branch}}
+            type=raw,priority=300,value={{branch}}-latest,event=branch,enable={{is_not_default_branch}}
+            type=raw,priority=300,value={{branch}}-{{date 'YYYYMMDD'}},event=branch,enable={{is_not_default_branch}}
+            type=raw,priority=200,value={{branch}},event=branch,enable={{is_not_default_branch}}
 
       - name: Setup build dir
         id: setup


### PR DESCRIPTION
I noticed a few redundant (and invalid) image tags which were created with the release **5.4.0**

This PR tries to get rid of them.

Examples (it happens only when doing a git tag):
> 15.0-
> 15.0--latest
> 15.0--20260528
> 
> 15.0-core-
> 15.0-core--latest
> 15.0-core--20260528
