### PR TITLE
fix: use ci-latest and ci-core-latest instead of ci-(4xx|5xx)-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,7 @@ jobs:
           VERSION=${{ matrix.odoo_serie }} SRC=build make setup
           echo "Dockerfile=./build/${{ matrix.flavor == 'core' && 'core.' || '' }}Dockerfile" >> $GITHUB_OUTPUT
           echo "python-from=${{ matrix.python }}-slim-trixie" >> $GITHUB_OUTPUT
-          echo "image-tag=ci-${{ matrix.flavor == 'core' && '5' || '4' }}xx-latest:${{ matrix.odoo_serie }}" >> $GITHUB_OUTPUT
+          echo "image-tag=ci-${{ matrix.flavor == 'core' && 'core-' || '' }}latest:${{ matrix.odoo_serie }}" >> $GITHUB_OUTPUT
 
       - name: Build
         uses: docker/build-push-action@v7

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifndef VERSION
 $(error VERSION is not set)
 endif
 ifndef IMAGE_LATEST
-IMAGE_LATEST=ci-4xx-latest:${VERSION}
+IMAGE_LATEST=ci-latest:${VERSION}
 endif
 BUILD_TAG=$(IMAGE_LATEST)
 

--- a/test.sh
+++ b/test.sh
@@ -30,7 +30,7 @@ fi
 export IMAGE_LATEST
 
 case $IMAGE_LATEST in
-  *-5xx-*)
+  *-core-*)
     TEST_SRC=./example-core
     BASE_PATH=.
     LOCAL_CODE_PATH=./odoo/addons


### PR DESCRIPTION
Docker image names "ci-4xx-latest" amd "ci-5xx-latest" do not make sense anymore.