### PR TITLE
feat: provide an immutable unaccent pg function

### DIFF
--- a/before-migrate-entrypoint.d/100_setup_unaccent
+++ b/before-migrate-entrypoint.d/100_setup_unaccent
@@ -1,0 +1,36 @@
+#!/bin/bash
+if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
+then
+    # we don't want odoo to automatically create the database,
+    # because this would not initialize unaccent as we want
+    createdb -O ${DB_USER} ${DB_NAME}
+fi
+
+psql ${db} << EOF
+
+-- cleanup
+  DO \$do\$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_extension e
+      JOIN pg_namespace n ON n.oid = e.extnamespace
+      WHERE e.extname = 'unaccent'
+        AND n.nspname = 'public'
+    ) THEN
+      DROP EXTENSION unaccent;
+    END IF;
+  END
+  \$do\$;
+
+  CREATE SCHEMA IF NOT EXISTS unaccent_schema; 
+  CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA unaccent_schema; 
+  CREATE OR REPLACE FUNCTION public.unaccent(text) 
+  RETURNS text 
+  LANGUAGE sql 
+  IMMUTABLE PARALLEL SAFE STRICT 
+  AS \$function\$ 
+     SELECT unaccent_schema.unaccent('unaccent_schema.unaccent', \$1) 
+  \$function\$ ;
+EOF
+

--- a/before-migrate-entrypoint.d/100_setup_unaccent
+++ b/before-migrate-entrypoint.d/100_setup_unaccent
@@ -1,36 +1,37 @@
 #!/bin/bash
+set -x
+
+# Odoo uses "unaccent" function for searches.  It is provided by PG extension.
+# However, this function needs to be "immutable" to be able to create indexes.
+#
+# When new database is created, Odoo tries to set the function immutable.
+# However it might not work in case the PostgreSQL server is hosted on a cloud platform.
+#
+# This is the reason for this workaround.
+#
+# Reference:
+# - https://github.com/odoo/odoo/blob/19.0/odoo/service/db.py#L155-L163
+# - https://github.com/odoo/odoo/pull/95943
+
 if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
 then
-    # we don't want odoo to automatically create the database,
-    # because this would not initialize unaccent as we want
-    createdb -O ${DB_USER} ${DB_NAME}
+    echo "Database does not exist, ignoring script"
+    exit 0
 fi
 
-psql ${db} << EOF
+# If 'unaccent' is already IMMUTABLE, do nothing
+if [ "$( psql -tAc "SELECT 1 FROM pg_proc WHERE proname = 'unaccent' AND provolatile = 'i' AND pronamespace = current_schema::regnamespace;" )" = "1" ]
+then
+    echo "Function 'unaccent' is already immutable. Skip"
+else
+    psql << EOF
+DROP EXTENSION IF EXISTS unaccent;
+CREATE SCHEMA IF NOT EXISTS unaccent_schema;
+CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA unaccent_schema;
 
--- cleanup
-  DO \$do\$
-  BEGIN
-    IF EXISTS (
-      SELECT 1
-      FROM pg_extension e
-      JOIN pg_namespace n ON n.oid = e.extnamespace
-      WHERE e.extname = 'unaccent'
-        AND n.nspname = 'public'
-    ) THEN
-      DROP EXTENSION unaccent;
-    END IF;
-  END
-  \$do\$;
-
-  CREATE SCHEMA IF NOT EXISTS unaccent_schema; 
-  CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA unaccent_schema; 
-  CREATE OR REPLACE FUNCTION public.unaccent(text) 
-  RETURNS text 
-  LANGUAGE sql 
-  IMMUTABLE PARALLEL SAFE STRICT 
-  AS \$function\$ 
-     SELECT unaccent_schema.unaccent('unaccent_schema.unaccent', \$1) 
-  \$function\$ ;
+CREATE OR REPLACE FUNCTION unaccent(value text) RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+RETURN (SELECT unaccent_schema.unaccent('unaccent_schema.unaccent', value));
 EOF
 
+fi

--- a/start-entrypoint.d/100_fix_indexes
+++ b/start-entrypoint.d/100_fix_indexes
@@ -1,0 +1,36 @@
+#! /bin/bash
+# This script can be removed when we have finished updating databases with
+# the configuration of the unaccentextension (odoo >= 16.0)
+
+if [ "${ODOO_VERSION%%.*}" -lt 16 ]; then
+    echo "Index fixing for unaccent: requires Odoo 16.0+"
+    exit 0
+fi
+
+if [ 0 = $(psql -Atc "SELECT COUNT(*) FROM pg_indexes WHERE indexdef LIKE '%gin_trgm%' AND indexdef NOT LIKE '%unaccent%'") ]
+then
+    echo "No indexes to fix"
+    exit 0
+fi
+
+odoo shell --no-http --log-handler=:ERROR --log-handler=odoo.schema:INFO << EOF
+cr = self.env.cr
+query = """SELECT indexname, tablename 
+FROM pg_indexes 
+WHERE indexdef LIKE '%gin_trgm%' 
+AND indexdef NOT LIKE '%unaccent%'"""
+cr.execute(query)
+tables = set()
+for indexname, tablename in cr.fetchall():
+    tables.add(tablename)
+    print(f"Fixing index {indexname} on table {tablename}")
+    cr.execute(f"DROP INDEX {indexname}")
+if tables:
+    # recreate the indexes with unaccent
+    models = set()
+    for model in self.env.registry.models.values():
+        if model._table in tables:
+            models.add(model._name)
+    self.env.registry.check_indexes(self.env.cr, models)
+self.env.cr.commit()
+EOF

--- a/start-entrypoint.d/100_fix_indexes
+++ b/start-entrypoint.d/100_fix_indexes
@@ -2,35 +2,45 @@
 # This script can be removed when we have finished updating databases with
 # the configuration of the unaccentextension (odoo >= 16.0)
 
-if [ "${ODOO_VERSION%%.*}" -lt 16 ]; then
-    echo "Index fixing for unaccent: requires Odoo 16.0+"
+if [ "${ODOO_VERSION%%.*}" -lt 16 -o "${ODOO_VERSION%%.*}" -gt 19 ]; then
+    echo "Index fixing for unaccent: requires Odoo [16.0 to 19.0]"
     exit 0
 fi
 
-if [ 0 = $(psql -Atc "SELECT COUNT(*) FROM pg_indexes WHERE indexdef LIKE '%gin_trgm%' AND indexdef NOT LIKE '%unaccent%'") ]
-then
+WHERE_CLAUSE="WHERE indexdef LIKE '%gin_trgm_ops%' AND indexdef NOT LIKE '%unaccent%' AND schemaname = current_schema"
+
+if [ 0 = $(psql -tAc "SELECT COUNT(*) FROM pg_indexes $WHERE_CLAUSE;") ]; then
     echo "No indexes to fix"
     exit 0
 fi
 
 odoo shell --no-http --log-handler=:ERROR --log-handler=odoo.schema:INFO << EOF
-cr = self.env.cr
-query = """SELECT indexname, tablename 
-FROM pg_indexes 
-WHERE indexdef LIKE '%gin_trgm%' 
-AND indexdef NOT LIKE '%unaccent%'"""
-cr.execute(query)
+import re
+
+query = """SELECT indexname, tablename, indexdef FROM pg_indexes $WHERE_CLAUSE;"""
+env.cr.execute(query)
+
 tables = set()
-for indexname, tablename in cr.fetchall():
+for indexname, tablename, indexdef in env.cr.fetchall():
+    # Odoo 17+ uses '__' as separator between table and column
+    # Note that index names longer than 63 chars are mangled, hence they are not detected
+    parsed = re.match(f"{tablename}__?(.+)_index", indexname)
+
+    # Sanity check, to avoid dropping non-standard indexes
+    colname = parsed and parsed.group(1)
+    if not colname:
+        print(f"Left unchanged: {indexdef}")
+        continue
     tables.add(tablename)
-    print(f"Fixing index {indexname} on table {tablename}")
-    cr.execute(f"DROP INDEX {indexname}")
+    print(f"Fixing index {indexname} on table {tablename} ({colname})")
+    env.cr.execute(f"DROP INDEX {indexname};")
+
 if tables:
     # recreate the indexes with unaccent
     models = set()
-    for model in self.env.registry.models.values():
+    for model in env.registry.models.values():
         if model._table in tables:
             models.add(model._name)
-    self.env.registry.check_indexes(self.env.cr, models)
-self.env.cr.commit()
+    env.registry.check_indexes(env.cr, models)
+env.cr.commit()
 EOF


### PR DESCRIPTION
Tests I did: 

* local test on alloboissons rebuilt with this image: get a production database, run odoo twice, check that the second time the fix index action does nothing
* local test on alloboissons project: start with no database, check that the `unaccent` function is created and that the installation of the modules creates the expected database indexes. 