### PR TITLE
imp: drop `running_env` in config file in recent versions of Odoo

### DIFF
--- a/18.0/templates/odoo.cfg.tmpl
+++ b/18.0/templates/odoo.cfg.tmpl
@@ -25,7 +25,6 @@ logfile = {{ default .Env.LOGFILE "None" }}
 log_db = {{ default .Env.LOG_DB "None" }}
 logrotate = True
 syslog = {{ default .Env.SYSLOG "False" }}
-running_env = {{ default .Env.RUNNING_ENV "dev" }}
 without_demo = {{ default .Env.WITHOUT_DEMO "True" }}
 server_wide_modules = {{ default .Env.SERVER_WIDE_MODULES "" }}
 ; db_sslmode =

--- a/19.0/templates/odoo.cfg.tmpl
+++ b/19.0/templates/odoo.cfg.tmpl
@@ -23,7 +23,6 @@ workers = {{ default .Env.WORKERS "4" }}
 logfile = {{ default .Env.LOGFILE "None" }}
 log_db = {{ default .Env.LOG_DB "None" }}
 syslog = {{ default .Env.SYSLOG "False" }}
-running_env = {{ default .Env.RUNNING_ENV "dev" }}
 with_demo = {{ default .Env.DEMO "False" }}
 server_wide_modules = {{ default .Env.SERVER_WIDE_MODULES "" }}
 http_interface = 0.0.0.0


### PR DESCRIPTION
Originally, this was the only way to configure the running environment for the server_environment module.

3 years ago, a PR improved the module in version 14.0, to read the running environment from the environment variable `RUNNING_ENV` instead of the config file, if set.

Original PR in 14.0:
- https://github.com/OCA/server-env/pull/146

Later, this PR was forward ported to 16.0 and 17.0 (sadly no 15.0):
- 15.0: NOT PORTED
- 16.0: https://github.com/OCA/server-env/pull/223
- 17.0: https://github.com/OCA/server-env/pull/189

Finally, it was fully integrated into the migrations to 18.0 and 19.0. So it's safe to assume that in 18.0 and 19.0, no matter the module version used, the running environment will be read from the RUNNING_ENV variable.

---

In 19.0, Odoo started complaining about unknown config file options, so this supresses the following warning:

```
WARNING ? odoo.tools.config: unknown option 'running_env' in the config file at
/etc/odoo.cfg, option stored as-is, without parsing
```