### PR TITLE
fix: update cryptography, lxml, pillow, vcrpy and pyasn1 dependencies

### DIFF
--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -1,6 +1,6 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==3.0.4
-cryptography==46.0.7 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 46.0.7 for security fixes
+cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5
@@ -10,17 +10,17 @@ greenlet==3.0.3 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble
 idna==3.8
 Jinja2==3.1.6 ; python_version >= '3.12'  # (Noble) compatibility with markupsafe
 libsass==0.22.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
-lxml==6.1.0; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.0 for security fixes
+lxml==6.1.1; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.1 for security fixes
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
 MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 num2words==0.5.6
 ofxparse==0.21; python_version > '3.9'  # (Jammy)
-Pillow==12.2.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.2.0 for security fixes
+Pillow==12.3.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.3.0 for security fixes
 polib==1.1.0
 psutil==5.9.8 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 pydot==1.4.1
-pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==46.0.5 and security patches
+pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
 PyPDF2==2.12.1 ; python_version >= '3.12' # (Noble) Compatibility with cryptography
 pyserial==3.4
 python-dateutil==2.8.2  # bumped because of requirement of algoliasearch

--- a/15.0/extra_requirements.txt
+++ b/15.0/extra_requirements.txt
@@ -18,7 +18,7 @@ requests-mock==1.12.1
 slugify==0.0.1
 stripe==10.8.0
 unidecode==1.3.8
-vcrpy==7.0.0
+vcrpy==8.2.1
 
 # Library dependency
 aiohttp==3.13.5
@@ -29,7 +29,7 @@ dateparser==1.2.0
 jmespath==1.0.1
 multidict==6.0.5
 pdfminer.six==20260107
-pyasn1==0.6.3
+pyasn1==0.6.4
 pycryptodome==3.20.0
 PyNaCl==1.5.0
 pytesseract==0.3.13

--- a/16.0/base_requirements.txt
+++ b/16.0/base_requirements.txt
@@ -2,7 +2,7 @@
 # python3-* equivalent distributed in Ubuntu 22.04 and Debian 11
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==4.0.0
-cryptography==46.0.7 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 46.0.7 for security fixes
+cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5
@@ -13,18 +13,18 @@ greenlet==3.0.3 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble
 idna==3.8
 Jinja2==3.1.6 ; python_version >= '3.12'  # (Noble) compatibility with markupsafe
 libsass==0.22.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
-lxml==6.1.0; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.0 for security fixes
+lxml==6.1.1; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.1 for security fixes
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
 MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 num2words==0.5.9
 ofxparse==0.21; python_version > '3.9'  # (Jammy)
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
-Pillow==12.2.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.2.0 for security fixes
+Pillow==12.3.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.3.0 for security fixes
 polib==1.1.0
 psutil==5.9.8 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 pydot==1.4.2
-pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==46.0.5 and security patches
+pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2  # bumped because of requirement of algoliasearch

--- a/16.0/extra_requirements.txt
+++ b/16.0/extra_requirements.txt
@@ -18,7 +18,7 @@ requests-mock==1.12.1
 slugify==0.0.1
 stripe==10.8.0
 unidecode==1.3.8
-vcrpy==7.0.0
+vcrpy==8.2.1
 
 # Library dependency
 aiohttp==3.13.5
@@ -29,7 +29,7 @@ dateparser==1.2.0
 jmespath==1.0.1
 multidict==6.0.5
 pdfminer.six==20260107
-pyasn1==0.6.3
+pyasn1==0.6.4
 pycryptodome==3.20.0
 PyNaCl==1.5.0
 pytesseract==0.3.13

--- a/17.0/base_requirements.txt
+++ b/17.0/base_requirements.txt
@@ -1,6 +1,6 @@
 Babel==2.10.3 ; python_version >= '3.11'
 chardet==5.2.0 ; python_version >= '3.11'
-cryptography==46.0.7 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 46.0.7 for security fixes
+cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
 decorator==5.1.1  ; python_version >= '3.11'
 docutils==0.20.1 ; python_version >= '3.11'
 ebaysdk==2.1.5
@@ -12,19 +12,19 @@ greenlet==3.0.3 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble
 idna==3.8
 Jinja2==3.1.6 ; python_version >= '3.12'  # (Noble) compatibility with markupsafe
 libsass==0.22.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
-lxml==6.1.0; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.0 for security fixes
+lxml==6.1.1; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.1 for security fixes
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
 MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 num2words==0.5.13 ; python_version >= '3.12'
 ofxparse==0.21
 openpyxl==3.1.2 ; python_version >= '3.12'
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
-Pillow==12.2.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.2.0 for security fixes
+Pillow==12.3.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.3.0 for security fixes
 polib==1.1.0
 psutil==5.9.8 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 pydot==1.4.2
-pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==46.0.5 and security patches
+pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2 ; python_version >= '3.11'

--- a/17.0/extra_requirements.txt
+++ b/17.0/extra_requirements.txt
@@ -18,7 +18,7 @@ requests-mock==1.12.1
 slugify==0.0.1
 stripe==10.8.0
 unidecode==1.3.8
-vcrpy==7.0.0
+vcrpy==8.2.1
 
 # Library dependency
 aiohttp==3.13.5
@@ -29,7 +29,7 @@ dateparser==1.2.0
 jmespath==1.0.1
 multidict==6.0.5
 pdfminer.six==20260107
-pyasn1==0.6.3
+pyasn1==0.6.4
 pycryptodome==3.20.0
 PyNaCl==1.5.0
 pytesseract==0.3.13

--- a/18.0/base_requirements.txt
+++ b/18.0/base_requirements.txt
@@ -4,7 +4,7 @@ asn1crypto==1.5.1 ; python_version >= '3.11'
 Babel==2.10.3 ; python_version >= '3.11'
 cbor2==5.9.0 ; python_version >= '3.12'  # Pin 5.9.0 for security fixes
 chardet==5.2.0 ; python_version >= '3.11'
-cryptography==46.0.7 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 46.0.7 for security fixes
+cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
 decorator==5.1.1  ; python_version >= '3.11'
 docutils==0.20.1 ; python_version >= '3.11'
 freezegun==1.2.1 ; python_version >= '3.11'
@@ -15,18 +15,18 @@ greenlet==3.0.3 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble
 idna==3.8 ; python_version >= '3.12'
 Jinja2==3.1.6 ; python_version > '3.10'
 libsass==0.22.0 ; python_version >= '3.11'  # (Noble) Mostly to have a wheel package
-lxml==6.1.0; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.0 for security fixes
+lxml==6.1.1; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.1 for security fixes
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
 MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 num2words==0.5.13 ; python_version >= '3.12'
 ofxparse==0.21
 openpyxl==3.1.2 ; python_version >= '3.12'
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
-Pillow==12.2.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.2.0 for security fixes
+Pillow==12.3.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.3.0 for security fixes
 polib==1.1.1
 psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
-pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==46.0.5 and security patches
+pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2 ; python_version >= '3.11'

--- a/18.0/extra_requirements.txt
+++ b/18.0/extra_requirements.txt
@@ -18,7 +18,7 @@ requests-mock==1.12.1
 slugify==0.0.1
 stripe==10.8.0
 unidecode==1.3.8
-vcrpy==7.0.0
+vcrpy==8.2.1
 
 # Library dependency
 aiohttp==3.13.5
@@ -28,7 +28,7 @@ dateparser==1.2.0
 jmespath==1.0.1
 multidict==6.0.5
 pdfminer.six==20260107
-pyasn1==0.6.3
+pyasn1==0.6.4
 pycryptodome==3.20.0
 PyNaCl==1.5.0
 pytesseract==0.3.13

--- a/19.0/base_requirements.txt
+++ b/19.0/base_requirements.txt
@@ -5,7 +5,7 @@ Babel==2.10.3 ; python_version >= '3.11' and python_version < '3.13'
 Babel==2.17.0 ; python_version >= '3.13'
 cbor2==5.9.0 ; python_version >= '3.12'  # Pin 5.9.0 for security fixes
 chardet==5.2.0 ; python_version >= '3.11'
-cryptography==46.0.7 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 46.0.7 for security fixes
+cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
 docutils==0.20.1 ; python_version >= '3.11'
 freezegun==1.2.1 ; python_version >= '3.11' and python_version < '3.13'
 freezegun==1.5.1 ; python_version >= '3.13'
@@ -17,19 +17,19 @@ greenlet==3.1.1 ; sys_platform != 'win32' and python_version >= '3.13'  # (Trixi
 idna==3.10 ; python_version >= '3.12'
 Jinja2==3.1.6 ; python_version > '3.10'
 libsass==0.22.0 ; python_version >= '3.11'  # (Noble) Mostly to have a wheel package
-lxml==6.1.0; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.0 for security fixes
+lxml==6.1.1; python_version >= '3.12' # (Noble - removed html clean); pin 6.1.1 for security fixes
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
 MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 num2words==0.5.13 ; python_version >= '3.12'
 ofxparse==0.21
 openpyxl==3.1.2 ; python_version >= '3.12'
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
-Pillow==12.2.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.2.0 for security fixes
+Pillow==12.3.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package; pin 12.3.0 for security fixes
 polib==1.1.1
 psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12' and python_version < '3.13' # (Noble)
 psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)
-pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==46.0.5 and security patches
+pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2 ; python_version >= '3.11'

--- a/19.0/extra_requirements.txt
+++ b/19.0/extra_requirements.txt
@@ -18,7 +18,7 @@ requests-mock==1.12.1
 slugify==0.0.1
 stripe==12.5.1
 unidecode==1.4.0
-vcrpy==7.0.0
+vcrpy==8.2.1
 
 # Library dependency
 aiohttp==3.13.5
@@ -28,7 +28,7 @@ dateparser==1.2.2
 jmespath==1.0.1
 multidict==6.6.4
 pdfminer.six==20260107
-pyasn1==0.6.3
+pyasn1==0.6.4
 pycryptodome==3.23.0
 PyNaCl==1.6.0
 pytesseract==0.3.13


### PR DESCRIPTION
Fixes GHSA-537c-gmf6-5ccf, CVE-2026-49825, CVE-2026-54058, CVE-2026-54059, CVE-2026-54060, CVE-2026-55379, CVE-2026-55380, CVE-2026-59197, CVE-2026-59199, CVE-2026-59200, CVE-2026-59204, CVE-2026-59205, CVE-2026-59885, CVE-2026-59886 and GHSA-rpj2-4hq8-938g

As reported by Trivy

pyopenssl and lxml are also bumped, required for compatibility with the new cryptography and lxml-html-clean versions.