### PR TITLE
BSRD-850: imp: always neutralize once when RUNNING_ENV is dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ steps on top of it.
 
 `ODOO_NEUTRALIZE` can be `True` or `False`. When set to `True` (default), the image will execute the official Odoo neutralization script if `RUNNING_ENV` is not set to `prod`. This deactivates outgoing emails, scheduled actions, and external payments to prevent accidental data leaks from production dumps.
 
+Databases that are already neutralized (flagged with the `database.is_neutralized` system parameter) are skipped, with one exception: when `RUNNING_ENV` is `dev`, the database is neutralized once more, so that a dump restored from another environment (integration, lab, ...) gets its environment-specific values reset locally. This is tracked with a separate `database.is_neutralized_for_dev` system parameter, so subsequent starts don't neutralize again.
+
     Note: This requires Odoo 16.0 or higher.
 
 ### CONFIDOO_APPLY

--- a/start-entrypoint.d/002_neutralize
+++ b/start-entrypoint.d/002_neutralize
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 if [ "${ODOO_VERSION%%.*}" -lt 16 ]; then
     echo "Neutralization skipped: requires Odoo 16.0+"
     exit 0
@@ -11,9 +12,24 @@ if [[ "$RUNNING_ENV" != "prod" && "$ODOO_NEUTRALIZE" == "True" ]]; then
         echo "Database does not exist, ignoring script"
         exit 0
     fi
-    if [ "$( psql -tAc "SELECT 1 FROM ir_config_parameter WHERE key='database.is_neutralized' AND value != '';" )" = '1' ]; then
-        echo "Database is already neutralized, skipping"
+    # On dev, the database usually comes from another environment where it was
+    # already neutralized. We still want to neutralize it locally, at least
+    # once, to reset the values that are environment specific (mail servers,
+    # crons, ...). A dedicated flag keeps track of it, so that we don't
+    # neutralize again on every start.
+    NEUTRALIZED_FLAG="database.is_neutralized"
+    if [[ "$RUNNING_ENV" == "dev" ]]; then
+        NEUTRALIZED_FLAG="database.is_neutralized_for_dev"
+    fi
+    if [ "$( psql -tAc "SELECT 1 FROM ir_config_parameter WHERE key='$NEUTRALIZED_FLAG' AND value != '';" )" = '1' ]; then
+        echo "Database is already neutralized ($NEUTRALIZED_FLAG), skipping"
         exit 0
     fi
     odoo neutralize
+    # Only on dev: on the other environments the flag set by `odoo neutralize`
+    # is enough. Writing it there would end up in the dumps, and would defeat
+    # the purpose of re-neutralizing them once when restored locally.
+    if [[ "$RUNNING_ENV" == "dev" ]]; then
+        psql -c "INSERT INTO ir_config_parameter (key, value) VALUES ('$NEUTRALIZED_FLAG', 'True') ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;"
+    fi
 fi


### PR DESCRIPTION
## Problem

`ODOO_NEUTRALIZE` skips databases that are already flagged as neutralized (`database.is_neutralized`).

A database restored locally almost always comes from another environment (integration, lab, ...) where it *was* already neutralized. So the check makes us skip the neutralization entirely, and the database keeps the values of the environment it came from: mail servers, crons, payment providers, ...

## Solution

On `RUNNING_ENV=dev`, guard the neutralization with a dedicated `database.is_neutralized_for_dev` system parameter instead of `database.is_neutralized`:

* a database restored from anywhere is neutralized once, locally;
* subsequent starts don't neutralize again, since it's not needed anymore.

The flag is only written on `dev`. On the other environments the flag set by `odoo neutralize` is enough, and writing ours there would end up inside the dumps, defeating the purpose.

Behavior on `prod` (never neutralized) and on the other non-prod environments (skipped when `database.is_neutralized` is set) is unchanged. `ODOO_NEUTRALIZE=False` is still the way to opt out.

Also replaced the explicit error propagation by `set -e`, so the flag can't be written if `odoo neutralize` fails — the neutralization is then retried on the next start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)