### PR TITLE
fix: compatibility with mail_environment

### DIFF
--- a/start-entrypoint.d/002_neutralize
+++ b/start-entrypoint.d/002_neutralize
@@ -25,7 +25,17 @@ if [[ "$RUNNING_ENV" != "prod" && "$ODOO_NEUTRALIZE" == "True" ]]; then
         echo "Database is already neutralized ($NEUTRALIZED_FLAG), skipping"
         exit 0
     fi
+
+    # If OCA 'mail_environment' is installed, it replaces some columns
+    # of "ir.mail_server" with dynamic values.  Neutralize script assume that
+    # these standard columns exist, so we create them before applying neutralization
+    if [ "$( psql -tAc "SELECT 1 FROM ir_module_module WHERE name = 'mail_environment' AND state != 'uninstalled';" )" = '1' ]; then
+        psql -c "ALTER TABLE ir_mail_server ADD IF NOT EXISTS smtp_encryption VARCHAR, ADD IF NOT EXISTS smtp_host VARCHAR, ADD IF NOT EXISTS smtp_port INT;"
+    fi
+
+    # Apply SQL scripts
     odoo neutralize
+
     # Only on dev: on the other environments the flag set by `odoo neutralize`
     # is enough. Writing it there would end up in the dumps, and would defeat
     # the purpose of re-neutralizing them once when restored locally.


### PR DESCRIPTION
With Odoo 16+, when `mail_environment` is installed, it crashes the server when a database is restored on a non-prod environment.
https://github.com/OCA/server-env/tree/16.0/mail_environment

This is the script which tries to insert values in removed columns:
https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/data/neutralize.sql#L5-L7

```sql
run-parts: executing /start-entrypoint.d/002_neutralize
2026-07-13 16:39:23,186 81 INFO ? odoo.cli.neutralize: Starting int database neutralization
2026-07-13 16:39:23,270 81 ERROR ? odoo.sql_db: bad query: -- deactivate mail servers

(...)
ERROR: column "smtp_port" of relation "ir_mail_server" does not exist
LINE 6: INSERT INTO ir_mail_server(name, smtp_port, smtp_host, smtp_...
                                         ^
2026-07-13 16:39:23,271 81 CRITICAL ? odoo.cli.neutralize: An error occurred during the neutralization. THE DATABASE IS NOT NEUTRALIZED!
run-parts: /start-entrypoint.d/002_neutralize exited with return code 1
```
Recommendation is to stop using `mail_environment`, and to switch to [confidoo](https://github.com/camptocamp/confidoo/)

However for existing projects, it needs to be fixed.

----

[UPDATE]

A deeper analysis was done by @ivantodorovich few months ago. I copy it here:

> The problem is `server_environment` converts regular fields into non stored computed ones, and if the project has gone through a migration.. then we executed the cleanup step that removes unused columns (OCA `database_cleanup`). Then, the neutralization queries fail. We're planning to rework or maybe even stop using server environment so that neutralize can work out of the box -- we want to use neutralize because it catches many secrets and keys that should not be copied into integration/labs without any maintenance from us (Odoo maintains them).
> In the meantime, there are two workarounds. Either one works:
> 
> - Disable the neutralization scripts with the env var
> - Re-create the missing database columns -- then they will be kept, until a future migration at least
