### PR TITLE
Pin kwkhtmltopdf for more robust build

### DIFF
--- a/install/kwkhtml_client.sh
+++ b/install/kwkhtml_client.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-curl -o kwkhtmltopdf_client -SL https://raw.githubusercontent.com/camptocamp/kwkhtmltopdf/master/client/python/kwkhtmltopdf_client.py
+curl -o kwkhtmltopdf_client -SL https://github.com/camptocamp/kwkhtmltopdf/raw/refs/tags/2.0.2/client/python/kwkhtmltopdf_client.py
 echo '8676b798f57c67e3a801caad4c91368929c427ce kwkhtmltopdf_client' | sha1sum -c -
 mv kwkhtmltopdf_client /usr/local/bin/wkhtmltopdf
 chmod a+x /usr/local/bin/wkhtmltopdf


### PR DESCRIPTION
Relying on `master` branch then doing verifying a checksum is not robust.

Use the latest tag instead.