### PR TITLE
fix: allow the command to be called with gosu odoo

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -98,7 +98,8 @@ if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] || [ "$BASE_CMD" = "m
     run-parts --exit-on-error --verbose "$BEFORE_MIGRATE_ENTRYPOINT_DIR"
   fi
 fi
-if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ]; then
+if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] ||
+    ([ "$BASE_CMD" = "gosu" ] && [[ "${ARGS[@]}" =~ "odoo migrate" ]] ); then
 
   # Bypass migrate when `odoo shell` or `odoo --help` are used
   if [[ ! " ${ARGS[@]} " =~ " --help " ]] && [[ ! " ${ARGS[@]:0:1} " =~ " shell " ]]; then


### PR DESCRIPTION
Without this fix, the start-entrypoint.d/ scripts are not run when the command of the container is something similar to 'gosu odoo' (whereas the before-migrate-entrypoint.d/ scripts are run). This is the case if the Chart used is >= 5.3.8.

--

Related change:
- camptocamp/odoo-platform-charts#166