### PR TITLE
fix: better detect when command is run as `gosu odoo`

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -91,8 +91,7 @@ if [ $EUID -eq 0 ]; then
   fi
 fi
 
-if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] || [ "$BASE_CMD" = "migrate" ] ||
-    ([ "$BASE_CMD" = "gosu" ] && [[ "${ARGS[@]}" =~ "odoo migrate" ]] ); then
+if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] || [ "$BASE_CMD" = "migrate" ]; then
   BEFORE_MIGRATE_ENTRYPOINT_DIR=$ODOO_BASE_PATH/before-migrate-entrypoint.d
   if [ -d "$BEFORE_MIGRATE_ENTRYPOINT_DIR" ]; then
     run-parts --exit-on-error --verbose "$BEFORE_MIGRATE_ENTRYPOINT_DIR"

--- a/common/env_odoo.sh
+++ b/common/env_odoo.sh
@@ -7,5 +7,11 @@ ODOO_BASE_PATH=""
 USER_ID=${LOCAL_USER_ID:-999}
 id -u odoo &> /dev/null || useradd --shell /bin/bash -u $USER_ID -o -c "" -m odoo
 
+# If run as "gosu odoo ...", shift arguments
+if [ "$(basename $1)" = "gosu" ]; then
+  test "$2" = odoo
+  shift 2
+fi
+
 run_as_odoo () { gosu odoo "$@"; }
 exec_as_odoo () { exec gosu odoo "$@"; }


### PR DESCRIPTION
Simpler fix for the issue with Chart 5.3.8 / 5.3.9

Replaces:
- #472

---

Without this fix, the start-entrypoint.d/ scripts are not run when the command of the container is something similar to 'gosu odoo' (whereas the before-migrate-entrypoint.d/ scripts are run). This is the case if the Chart used is >= 5.3.8.

--

Related change:
- camptocamp/odoo-platform-charts#166