### PR TITLE
ci: remove parasite image tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,9 +73,9 @@ jobs:
             type=schedule,priority=800
             type=raw,priority=500,value=latest,enable={{is_default_branch}}
             type=raw,priority=400,value={{date 'YYYYMMDD'}},enable={{is_default_branch}}
-            type=raw,priority=300,value={{branch}}-latest,event=branch,enable={{is_not_default_branch}}
-            type=raw,priority=300,value={{branch}}-{{date 'YYYYMMDD'}},event=branch,enable={{is_not_default_branch}}
-            type=raw,priority=200,value={{branch}},event=branch,enable={{is_not_default_branch}}
+            type=raw,priority=300,value={{branch}}-latest,event=push,enable={{is_not_default_branch}}
+            type=raw,priority=300,value={{branch}}-{{date 'YYYYMMDD'}},event=push,enable={{is_not_default_branch}}
+            type=raw,priority=200,value={{branch}},event=push,enable={{is_not_default_branch}}
 
       - name: Setup build dir
         id: setup


### PR DESCRIPTION
Fix a syntax mistake in previous PR:
- #455

---

Wrong tags were still present for release 5.4.1:

```
# 17.0-core-
# 17.0-core--latest
# 17.0-core--20260803

# 19.0-
# 19.0--latest
# 19.0--20260803
```

in addition to the valid ones:
```
# 17.0-core-5.4.1
# 17.0-core-latest
# 17.0-core-20260803

# 19.0-5.4.1
# 19.0-latest
# 19.0-20260803
```