### PR TITLE
fix: update cryptography, pyopenssl and aiohttp dependencies

### DIFF
--- a/15.0/base_requirements.txt
+++ b/15.0/base_requirements.txt
@@ -1,6 +1,6 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==3.0.4
-cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
+cryptography==50.0.0 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 50.0.0 for security fixes
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5
@@ -20,7 +20,7 @@ polib==1.1.0
 psutil==5.9.8 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 pydot==1.4.1
-pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
+pyopenssl==26.4.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==50.0.0 and security patches
 PyPDF2==2.12.1 ; python_version >= '3.12' # (Noble) Compatibility with cryptography
 pyserial==3.4
 python-dateutil==2.8.2  # bumped because of requirement of algoliasearch

--- a/15.0/extra_requirements.txt
+++ b/15.0/extra_requirements.txt
@@ -21,7 +21,7 @@ unidecode==1.3.8
 vcrpy==8.2.1
 
 # Library dependency
-aiohttp==3.13.5
+aiohttp==3.14.3
 asn1crypto==1.5.1
 bcrypt==4.2.0
 botocore==1.35.6

--- a/16.0/base_requirements.txt
+++ b/16.0/base_requirements.txt
@@ -2,7 +2,7 @@
 # python3-* equivalent distributed in Ubuntu 22.04 and Debian 11
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==4.0.0
-cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
+cryptography==50.0.0 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 50.0.0 for security fixes
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5
@@ -24,7 +24,7 @@ polib==1.1.0
 psutil==5.9.8 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 pydot==1.4.2
-pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
+pyopenssl==26.4.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==50.0.0 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2  # bumped because of requirement of algoliasearch

--- a/16.0/extra_requirements.txt
+++ b/16.0/extra_requirements.txt
@@ -21,7 +21,7 @@ unidecode==1.3.8
 vcrpy==8.2.1
 
 # Library dependency
-aiohttp==3.13.5
+aiohttp==3.14.3
 asn1crypto==1.5.1
 bcrypt==4.2.0
 botocore==1.35.6

--- a/17.0/base_requirements.txt
+++ b/17.0/base_requirements.txt
@@ -1,6 +1,6 @@
 Babel==2.10.3 ; python_version >= '3.11'
 chardet==5.2.0 ; python_version >= '3.11'
-cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
+cryptography==50.0.0 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 50.0.0 for security fixes
 decorator==5.1.1  ; python_version >= '3.11'
 docutils==0.20.1 ; python_version >= '3.11'
 ebaysdk==2.1.5
@@ -24,7 +24,7 @@ polib==1.1.0
 psutil==5.9.8 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 pydot==1.4.2
-pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
+pyopenssl==26.4.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==50.0.0 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2 ; python_version >= '3.11'

--- a/17.0/extra_requirements.txt
+++ b/17.0/extra_requirements.txt
@@ -21,7 +21,7 @@ unidecode==1.3.8
 vcrpy==8.2.1
 
 # Library dependency
-aiohttp==3.13.5
+aiohttp==3.14.3
 asn1crypto==1.5.1
 bcrypt==4.2.0
 botocore==1.35.6

--- a/18.0/base_requirements.txt
+++ b/18.0/base_requirements.txt
@@ -4,7 +4,7 @@ asn1crypto==1.5.1 ; python_version >= '3.11'
 Babel==2.10.3 ; python_version >= '3.11'
 cbor2==5.9.0 ; python_version >= '3.12'  # Pin 5.9.0 for security fixes
 chardet==5.2.0 ; python_version >= '3.11'
-cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
+cryptography==50.0.0 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 50.0.0 for security fixes
 decorator==5.1.1  ; python_version >= '3.11'
 docutils==0.20.1 ; python_version >= '3.11'
 freezegun==1.2.1 ; python_version >= '3.11'
@@ -26,7 +26,7 @@ Pillow==12.3.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel pack
 polib==1.1.1
 psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
-pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
+pyopenssl==26.4.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==50.0.0 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2 ; python_version >= '3.11'

--- a/18.0/extra_requirements.txt
+++ b/18.0/extra_requirements.txt
@@ -21,7 +21,7 @@ unidecode==1.3.8
 vcrpy==8.2.1
 
 # Library dependency
-aiohttp==3.13.5
+aiohttp==3.14.3
 bcrypt==4.2.0
 botocore==1.35.6
 dateparser==1.2.0

--- a/19.0/base_requirements.txt
+++ b/19.0/base_requirements.txt
@@ -5,7 +5,7 @@ Babel==2.10.3 ; python_version >= '3.11' and python_version < '3.13'
 Babel==2.17.0 ; python_version >= '3.13'
 cbor2==5.9.0 ; python_version >= '3.12'  # Pin 5.9.0 for security fixes
 chardet==5.2.0 ; python_version >= '3.11'
-cryptography==48.0.1 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 48.0.1 for security fixes
+cryptography==50.0.0 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 50.0.0 for security fixes
 docutils==0.20.1 ; python_version >= '3.11'
 freezegun==1.2.1 ; python_version >= '3.11' and python_version < '3.13'
 freezegun==1.5.1 ; python_version >= '3.13'
@@ -29,7 +29,7 @@ polib==1.1.1
 psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12' and python_version < '3.13' # (Noble)
 psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)
-pyopenssl==26.2.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==48.0.1 and security patches
+pyopenssl==26.4.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==50.0.0 and security patches
 PyPDF2==2.12.1 ; python_version > '3.10'
 pyserial==3.5
 python-dateutil==2.8.2 ; python_version >= '3.11'

--- a/19.0/extra_requirements.txt
+++ b/19.0/extra_requirements.txt
@@ -21,7 +21,7 @@ unidecode==1.4.0
 vcrpy==8.2.1
 
 # Library dependency
-aiohttp==3.13.5
+aiohttp==3.14.3
 bcrypt==4.3.0
 botocore==1.40.30
 dateparser==1.2.2


### PR DESCRIPTION
Fixes CVE-2026-69244, CVE-2026-69247 and CVE-2026-69249 as reported by Trivy.

pyopenssl is also bumped, required for compatibility with the new cryptography version.