### PR TITLE
fix: remove error message when running runmigration

### DIFF
--- a/common/env_odoo.sh
+++ b/common/env_odoo.sh
@@ -8,8 +8,8 @@ USER_ID=${LOCAL_USER_ID:-999}
 id -u odoo &> /dev/null || useradd --shell /bin/bash -u $USER_ID -o -c "" -m odoo
 
 # If run as "gosu odoo ...", shift arguments
-if [ "$(basename $1)" = "gosu" ]; then
-  test "$2" = odoo
+if [ "$(basename "${1-}")" = "gosu" ]; then
+  test "${2-}" = odoo
   shift 2
 fi
 


### PR DESCRIPTION
Fix error seen on CI "migration" job:
```
basename: missing operand
Try 'basename --help' for more information.
```