### PR TITLE
fix: psql already read values PGHOST/PGUSER from environment

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -77,8 +77,8 @@ if [ -z "$(pip list --format=columns | grep "/odoo" | grep -v "/odoo/src")" ]; t
 fi
 
 
-# Wait until postgres is up
-wait_postgres.sh
+# Wait until PostgreSQL is up
+wait_postgres 30s
 
 if [ $EUID -eq 0 ]; then
   # Not for core image

--- a/bin/env_postgres.sh
+++ b/bin/env_postgres.sh
@@ -1,5 +1,5 @@
 
-if [ ${DB_USER-} ]; then
+if [ -z "${PGUSER-}" ] && [ -n "${DB_USER-}" ]; then
   export PGHOST=$DB_HOST
   export PGPORT=$DB_PORT
   export PGUSER=$DB_USER
@@ -10,3 +10,23 @@ if [ ${DB_USER-} ]; then
     export PGPASSWORD=$DB_PASSWORD
   fi
 fi
+
+wait_postgres () {
+  TIMEOUT="${1:-30s}"
+  # Wait until PostgreSQL is running.
+  if [ -d "$DB_HOST" ]; then
+      dockerize -timeout $TIMEOUT -wait "unix://${DB_HOST}/.s.PGSQL.${DB_PORT}"
+  else
+      dockerize -timeout $TIMEOUT -wait "tcp://${DB_HOST}:${DB_PORT}"
+  fi
+
+  # now the port is up but sometimes server is not ready yet:
+  # 'createdb: could not connect to database template1: FATAL:  the database system is starting up'
+  # we retry if we get this error
+
+  while [ "$(psql -c '' postgres 2>&1)" = "psql: FATAL:  the database system is starting up" ]
+  do
+    echo "Waiting for the database system to start up"
+    sleep 0.1
+  done
+}

--- a/bin/runmigration
+++ b/bin/runmigration
@@ -32,7 +32,6 @@ set -e
 
 . db_cache_helpers.sh
 . env_odoo.sh
-wait_postgres.sh
 
 # Set default values
 : ${CREATE_DB_CACHE:=false} ${LOAD_DB_CACHE:=true} ${CACHE_DIR:=/tmp/cachedb} ${DB_NAME:=odoo_mig}

--- a/bin/runtests
+++ b/bin/runtests
@@ -28,7 +28,6 @@ set -e
 
 # TODO: if we are not on CI, make a template then run tests on a copy
 . db_cache_helpers.sh
-wait_postgres.sh
 
 LOCAL_CODE_PATH=${LOCAL_CODE_PATH:-/odoo/local-src}
 ODOO_BIN_PATH=/odoo/src/odoo/odoo-bin  # Core image layout

--- a/bin/wait_postgres.sh
+++ b/bin/wait_postgres.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
 #
-# Wait until postgresql is running.
+# Keep for backward compatibility.  For example `odoo-upgrade-tool` depends on it.
 #
+
 set -e
 
-if [[ -d $DB_HOST ]]; then
-    dockerize -timeout 30s -wait unix://${DB_HOST}/.s.PGSQL.${DB_PORT}
-else
-    dockerize -timeout 30s -wait tcp://${DB_HOST}:${DB_PORT}
-fi
+. env_postgres.sh
 
-# now the port is up but sometimes postgres is not totally ready yet:
-# 'createdb: could not connect to database template1: FATAL:  the database system is starting up'
-# we retry if we get this error
-
-while [ "$(PGPASSWORD=$DB_PASSWORD psql -h ${DB_HOST} -U $DB_USER -c '' postgres 2>&1)" = "psql: FATAL:  the database system is starting up" ]
-do
-  echo "Waiting for the database system to start up"
-  sleep 0.1
-done
+wait_postgres ${1-}


### PR DESCRIPTION
Refactor code related to postgres:
- psql already read values PGHOST/PGUSER from environment, no need to pass explicit values
- also remove redundant calls to `wait_postgres`, since it is already in the common entrypoint
- and declare a function instead of a separate script `wait_postgres.sh`
